### PR TITLE
Add routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "pino": "^8.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.8.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3896,6 +3897,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
+      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -20593,6 +20602,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
+      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "dependencies": {
+        "@remix-run/router": "1.3.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
+      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "dependencies": {
+        "@remix-run/router": "1.3.3",
+        "react-router": "6.8.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "pino": "^8.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.8.2",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+# https://docs.netlify.com/routing/redirects/
+
+/*  /index.html  200

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,12 @@
 import React from 'react';
 import { Header } from './Header';
-import logo from './react-logo.svg';
+import { Placeholder } from './Placeholder';
 import './App.css';
 
 const App = () => (
   <div className="App">
     <Header />
-    <main>
-      <img src={logo} className="React-logo" alt="logo" />
-      <h1>
-        Data Viewer
-      </h1>
-      <p>
-        <a
-          className="App-link"
-          href="https://github.com/PhilanthropyDataCommons/data-viewer/"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Repository
-        </a>
-      </p>
-      <p>
-        <a
-          className="App-link"
-          href="https://philanthropydatacommons.org/"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Website
-        </a>
-      </p>
-    </main>
+    <Placeholder />
   </div>
 );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
+import { Route, Routes } from 'react-router-dom';
 import { Header } from './Header';
+import { NotFound } from './NotFound';
 import { Placeholder } from './Placeholder';
 import './App.css';
 
 const App = () => (
   <div className="App">
     <Header />
-    <Placeholder />
+    <Routes>
+      <Route path="/" element={<Placeholder />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
   </div>
 );
 

--- a/src/NotFound.tsx
+++ b/src/NotFound.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+const NotFound = () => {
+  const location = useLocation();
+  return (
+    <main>
+      <h1>Page Not Found</h1>
+      <p>
+        We do not know the route
+        {' '}
+        <code>
+          {location.pathname}
+        </code>
+      </p>
+    </main>
+  );
+};
+
+export { NotFound };

--- a/src/Placeholder.test.tsx
+++ b/src/Placeholder.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { App } from './App';
+import { Placeholder } from './Placeholder';
 
 test('renders app name', () => {
-  render(<App />);
+  render(<Placeholder />);
   const nameElement = screen.getByText(/data viewer/i);
   expect(nameElement).toBeInTheDocument();
 });

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import logo from './react-logo.svg';
+
+const Placeholder = () => (
+  <main>
+    <img src={logo} className="React-logo" alt="logo" />
+    <h1>
+      Data Viewer
+    </h1>
+    <p>
+      <a
+        className="App-link"
+        href="https://github.com/PhilanthropyDataCommons/data-viewer/"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        Repository
+      </a>
+    </p>
+    <p>
+      <a
+        className="App-link"
+        href="https://philanthropydatacommons.org/"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        Website
+      </a>
+    </p>
+  </main>
+);
+
+export { Placeholder };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import { App } from './App';
 import { reportWebVitals } from './reportWebVitals';
@@ -12,7 +13,9 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </React.StrictMode>,
   );
 } else {


### PR DESCRIPTION
Install [react-router](https://reactrouter.com/en/main), and set up a few routes: the existing placeholder content, and a 404 error page. Hopefully, this will be enough to set the pattern for @reefdog to work on adding more pages if needed, but we'll figure that out as we go!

Note that this has merge conflicts with #28; once that PR is merged, I'll rebase and resolve them.

Issue https://github.com/PhilanthropyDataCommons/data-viewer/issues/10 Scaffold routing and page construction