### PR TITLE
Move example stories into `example/` directory

### DIFF
--- a/src/stories/example/Button.stories.ts
+++ b/src/stories/example/Button.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Button } from '../components/example/Button';
+import { Button } from '../../components/example/Button';
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta = {

--- a/src/stories/example/Header.stories.ts
+++ b/src/stories/example/Header.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Header } from '../components/example/Header';
+import { Header } from '../../components/example/Header';
 
 const meta = {
   title: 'Example/Header',

--- a/src/stories/example/Page.stories.ts
+++ b/src/stories/example/Page.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 
-import { Page } from '../pages/example/Page';
+import { Page } from '../../pages/example/Page';
 
 const meta = {
   title: 'Example/Page',


### PR DESCRIPTION
This PR includes a small miss from #32.

I didn’t understand the importance of story placement, and left the example stories in the root `stories/` directory. Now, writing stories of my own for #12, I want these examples to live in `stories/example/`. So, this PR moves them there.

Affects #10 (which is already closed)