### PR TITLE
Create Button component and story

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import "../src/index.css"
 
 const preview: Preview = {
   parameters: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@axa-fr/react-oidc": "^6.15.6",
+        "@heroicons/react": "^2.0.16",
         "pino": "^8.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2937,6 +2938,14 @@
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.16.tgz",
+      "integrity": "sha512-x89rFxH3SRdYaA+JCXwfe+RkE1SFTo9GcOkZettHer71Y3T7V+ogKmfw5CjTazgS3d0ClJ7p1NA+SP7VQLQcLw==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@axa-fr/react-oidc": "^6.15.6",
+    "@heroicons/react": "^2.0.16",
     "pino": "^8.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import './button.css';
+
+interface ButtonProps {
+  /**
+   * Contents of a `<Button>` can be a mix of strings and JSX elements,
+   * and will be flex-aligned.
+   */
+  children: JSX.Element | JSX.Element[] | string;
+  color?: 'gray' | 'blue' | 'red';
+  /**
+   * Makes the button dark with light text.
+   */
+  inverted?: boolean;
+  /**
+   * Adds a visible border to the button.
+   */
+  bordered?: boolean;
+  /**
+   * Adds a notification disc to the button.
+   */
+  notification?: boolean;
+  disabled?: boolean;
+  /**
+   * Optional click handler
+   */
+  onClick?: () => void;
+}
+
+/**
+ * Primary UI component for user interaction.
+ */
+export const Button = ({
+  children,
+  color = 'gray',
+  inverted = false,
+  bordered = true,
+  notification = false,
+  disabled = false,
+  onClick = (() => true),
+}: ButtonProps) => {
+  const buttonClassNames = [
+    'button',
+    `button--color-${color}`,
+  ];
+
+  if (inverted) {
+    buttonClassNames.push('button--inverted');
+  }
+
+  if (bordered) {
+    buttonClassNames.push('button--bordered');
+  }
+
+  if (notification) {
+    buttonClassNames.push('button--notification');
+  }
+
+  return (
+    <button
+      type="button"
+      className={buttonClassNames.join(' ')}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -1,0 +1,100 @@
+:root {
+  --button--focus-color: blue;
+  --button--font-size: 0.9rem;
+  /* These next values should be relative to the button's font-size, so we switch to `em` units. */
+  --button--height: 3.15em;
+  --button--icon-size: 1.7em;
+
+  /* V-padding based on desired button height minus font-height. */
+  --button--padding-y: calc((var(--button--height) - var(--button--font-size)) / 2);
+  /* H-padding based on desired button width minus icon size. (Smallest expected content.) */
+  --button--padding-x: calc((var(--button--height) - var(--button--icon-size)) / 2);
+}
+
+.button {
+  /* Nuclear unset of browser defaults: we want to completely define button styles. */
+  all: unset;
+  box-sizing: border-box;
+  cursor: pointer;
+
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-family: var(--font-family--sans-serif);
+  font-weight: 600;
+  font-size: var(--button--font-size);
+  line-height: 1;
+  letter-spacing: normal;
+  height: var(--button--height);
+  padding: var(--button--padding-y) var(--button--padding-x);
+
+  transition-property: background-color, color, border-color, opacity;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: calc(var(--button--padding-x) / 2);
+
+  /* Standard, default theme. */
+  --button--border-color: var(--button--primary-color);
+  --button--notification-color: var(--button--primary-color);
+  background-color: var(--button--contrast-color);
+  color: var(--button--primary-color);
+}
+
+.button:focus {
+  outline: 2px solid var(--button--focus-color);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button > svg {
+  height: var(--button--icon-size);
+  width: var(--button--icon-size);;
+}
+
+.button--color-gray {
+  --button--primary-color: var(--color--gray--dark);
+  --button--contrast-color: var(--color--gray--light);
+}
+
+.button--color-blue {
+  --button--primary-color: var(--color--blue);
+  --button--contrast-color: var(--color--gray--light);
+}
+
+.button--color-red {
+  --button--primary-color: var(--color--red);
+  --button--contrast-color: var(--color--gray--light);
+}
+
+.button--inverted {
+  --button--border-color: transparent;
+  --button--notification-color: var(--button--contrast-color);
+  background-color: var(--button--primary-color);
+  color: var(--button--contrast-color);
+}
+
+.button--bordered {
+  border-color: var(--button--border-color);
+}
+
+.button--notification {
+  position: relative;
+}
+
+.button--notification::after {
+  content: "";
+  border-radius: 50%;
+  width: 0.65em;
+  height: 0.65em;
+  background-color: var(--button--notification-color);
+
+  /* If we dislike this design, then remove the absolute positioning and give this element a
+     margin-left equal to the `gap` property above. */
+  position: absolute;
+  top: 3px;
+  right: 3px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,10 @@
 :root {
+  --color--gray--dark: #444;
+  --color--gray--medium: #BBB;
+  --color--gray--light: #FAFAFA;
+  --color--blue: #1176BC;
+  --color--red: #892929;
+
   --font-size: 16px;
   --line-height: 1.4;
   --font-family--sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   --font-family--monospace: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+
+  --transition-duration: 200ms;
 }
 
 body {
@@ -24,4 +26,5 @@ code {
 *:before,
 *:after {
   box-sizing: border-box;
+  transition-duration: var(--transition-duration);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,9 @@ body {
 code {
   font-family: var(--font-family--monospace);
 }
+
+*,
+*:before,
+*:after {
+  box-sizing: border-box;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,21 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+:root {
+  --font-size: 16px;
+  --line-height: 1.4;
+  --font-family--sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
+  --font-family--monospace: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family--sans-serif);
+  font-size: var(--font-size);
+  line-height: var(--line-height);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: var(--font-family--monospace);
 }

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline';
+
+import { Button } from '../components/Button';
+
+const meta = {
+  component: Button,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Button',
+  },
+};
+
+export const Blue: Story = {
+  args: {
+    color: 'blue',
+    children: 'Button',
+  },
+};
+
+export const Red: Story = {
+  args: {
+    color: 'red',
+    children: 'Button',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    color: 'blue',
+    bordered: true,
+    children: (
+      <>
+        <AdjustmentsHorizontalIcon />
+        Button
+      </>
+    ),
+  },
+};
+
+export const WithIconAndNotification: Story = {
+  args: {
+    color: 'blue',
+    bordered: true,
+    notification: true,
+    children: (
+      <>
+        <AdjustmentsHorizontalIcon />
+        Button
+      </>
+    ),
+  },
+};
+
+export const Inverted: Story = {
+  args: {
+    color: 'blue',
+    inverted: true,
+    children: 'Button',
+  },
+};
+
+export const InvertedWithIcon: Story = {
+  args: {
+    color: 'blue',
+    inverted: true,
+    children: (
+      <>
+        <AdjustmentsHorizontalIcon />
+        Button
+      </>
+    ),
+  },
+};
+
+export const InvertedWithIconAndNotification: Story = {
+  args: {
+    color: 'blue',
+    inverted: true,
+    notification: true,
+    children: (
+      <>
+        <AdjustmentsHorizontalIcon />
+        Button
+      </>
+    ),
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    children: (
+      <AdjustmentsHorizontalIcon />
+    ),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Button',
+    disabled: true,
+  },
+};


### PR DESCRIPTION
This PR adds our `Button` component as designed in the Figma UI, along with all its various possible states. It also adds a Storybook story to demonstrate those states and allow playing with the various arguments.

We'll be adding more components, but I wanted to deliver this PR quickly to demonstrate patterns and get any overall feedback.

It includes some related global work, such as including global CSS in Storybook previews and affecting global styles and CSS variables. This work is arguably beyond this PR, but was a prerequisite to it and still relevant to the attached issue.

It also adds the [Heroicons](https://heroicons.com/) React library, which we use for icons (such as those in buttons).

**Testing:**
- `npm i` to get `@heroicons/react`
- `npm run storybook`
- Hit http://localhost:6006/?path=/docs/stories-button--docs and play with the button!

Affects #12