### PR TITLE
Log in through OpenID Connect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Built-in Create React App environment variables
+# See https://create-react-app.dev/docs/advanced-configuration
+# for full list and documentation
+#DISABLE_ESLINT_PLUGIN=false
+#PORT=3000
+
+# Show logs in the browser console
+# See https://github.com/pinojs/pino/blob/49a29bb9d7895e791e7166fadfd7fd379f8db504/docs/api.md#loggerlevels-object
+#REACT_APP_LOG_LEVEL=debug
+
+# OpenID Connect configuration
+# The authority URL is the root which contains the OpenID Provider Configuration
+# https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest
+# In Keycloak, this is realm-local; do not include the trailing
+# `/.well-known/openid-configuration` path
+REACT_APP_OIDC_AUTHORITY=https://auth.example.com/realms/example
+
+# The client ID is assigned by the IdP
+REACT_APP_OIDC_CLIENT_ID=example-data-viewer

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# @axa-fr/react-oidc generated files
+/public/OidcServiceWorker.js
+/public/OidcTrustedDomains.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
 # data-viewer
 A UI for interacting with the data stored in the PDC service
 
+## Dependencies
+
+The application depends on an
+Open ID Connect ("OIDC")
+identity provider ("IdP")
+for authentication.
+It should be agnostic about what kind of IdP is used.
+To use the data-viewer application,
+you will need to be able to log in.
+
+## Configuration
+
+### Identity Provider
+
+The IdP needs a client for the data-viewer.
+The IdP should be configured for the client to use the
+[Authorization Code flow](https://oauth.net/2/grant-types/authorization-code/).
+This client is a public client,
+and so should *not* have a secret,
+and should not be able to log in with a client credentials grant.
+
+Set the client root URL to the app's URL
+(or `http://localhost:${PORT}` in development),
+and set the redirect URI to `/authentication/callback`.
+
+### Development
+
+Copy the `.env.example` file to `.env.local`,
+and replace the placeholder values with your specifics.
+Your new `.env.local` file will not be picked up by git.
+
+### Production
+
+The environment variables documented in `.env.example`
+will need to be configured in your deployment system;
+the values must be present at build time.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "data-viewer",
       "version": "0.1.0",
       "dependencies": {
+        "@axa-fr/react-oidc": "^6.15.6",
         "pino": "^8.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -67,6 +68,19 @@
       },
       "bin": {
         "x-default-browser": "bin/x-default-browser.js"
+      }
+    },
+    "node_modules/@axa-fr/react-oidc": {
+      "version": "6.15.6",
+      "resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-6.15.6.tgz",
+      "integrity": "sha512-mfKB0bZAq8seeQEv1Cs7dHUzLbK77l2kNgAvMOL3uZ5pPDFUZp0/2fXA+M0mF4UVHrWttY+q3ItOYIZKQNzBSA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "base64-js": "1.5.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@axa-fr/react-oidc": "^6.15.6",
     "pino": "^8.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { User } from './User';
 import logo from '../images/logo.png';
 
 const Header = () => (
   <header className="App-header">
     <img src={logo} className="App-logo" alt="logo" />
+    <User />
   </header>
 );
 

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useOidc, useOidcUser, OidcUserStatus } from '@axa-fr/react-oidc';
+import { getLogger } from '../logger';
+
+const logger = getLogger('<User>');
+
+const User = () => {
+  const { oidcUser, oidcUserLoadingState } = useOidcUser();
+  const { login } = useOidc();
+
+  switch (oidcUserLoadingState) {
+    case OidcUserStatus.Loading:
+      return <p>User information loading...</p>;
+    case OidcUserStatus.Unauthenticated:
+      return (
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => { login('/').catch(logger.error); }}
+        >
+          Login
+        </button>
+      );
+    case OidcUserStatus.LoadingError:
+      return <p>Failed to load user information</p>;
+    default:
+      return (
+        <div>
+          {oidcUser.name}
+        </div>
+      );
+  }
+};
+
+export { User };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { OidcProvider } from '@axa-fr/react-oidc';
 import './index.css';
 import { App } from './App';
+import { getConfiguration } from './oidc-config';
 import { reportWebVitals } from './reportWebVitals';
 import { getLogger } from './logger';
 
 const logger = getLogger('index');
+
+const configuration = getConfiguration(
+  process.env.REACT_APP_OIDC_AUTHORITY,
+  process.env.REACT_APP_OIDC_CLIENT_ID,
+);
+logger.debug(configuration, 'OIDC Configuration');
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <OidcProvider configuration={configuration}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </OidcProvider>
     </React.StrictMode>,
   );
 } else {

--- a/src/oidc-config.test.ts
+++ b/src/oidc-config.test.ts
@@ -1,0 +1,19 @@
+import { getConfiguration } from './oidc-config';
+
+test('configuration fails with missing authority', () => {
+  expect(() => getConfiguration(undefined, 'client-id')).toThrow(/authority/);
+});
+
+test('configuration fails with missing client ID', () => {
+  expect(() => getConfiguration('https://auth.example.com', undefined)).toThrow(/client/);
+});
+
+test('configuration succeeds with valid arguments', () => {
+  const authority = 'https://auth.example.com';
+  const clientId = 'client-id';
+  const configuration = getConfiguration(authority, clientId);
+  expect(configuration).toMatchObject({
+    authority,
+    client_id: clientId,
+  });
+});

--- a/src/oidc-config.ts
+++ b/src/oidc-config.ts
@@ -1,0 +1,24 @@
+import type { OidcConfiguration } from '@axa-fr/react-oidc';
+
+const getConfiguration = (
+  authority?: string,
+  clientId?: string,
+): OidcConfiguration => {
+  if (!authority) {
+    throw new Error('No OpenID Connect authority configured');
+  }
+
+  if (!clientId) {
+    throw new Error('No OpenID Connect client ID configured');
+  }
+
+  return {
+    authority,
+    client_id: clientId,
+    redirect_uri: `${window.location.origin}/authentication/callback`,
+    silent_redirect_uri: `${window.location.origin}/authentication/silent-callback`,
+    scope: 'openid',
+  };
+};
+
+export { getConfiguration };


### PR DESCRIPTION
Use the [`@axa-fr/react-oidc` library](https://www.npmjs.com/package/@axa-fr/react-oidc) to allow logging in via OpenID Connect. Add a `<User>` component to the `<Header>` that will show either a login button or the current user's name.

Note that the login button will probably not last long-term, but until we start showing any real data, it's a useful placeholder. It also looks good during demos, rather than the automatic login I expect we'll want. The `<User>` component is also unstyled for the moment; this commit is more focused on the functionality.

This adds a fair bit of required configuration. Add an `.env.example` file documenting several environment variables, both new and existing, and both optional and required.

The library supports service-worker-only communication between the app and the API, which is intended to improve security; at least for the moment, do not opt in, as we still need to figure out how to handle authentication in PR deploy previews. This may be something we want eventually, at which point we should commit the currently-ignored service worker & configuration files.

I did work far enough forward to confirm that I could make authenticated requests to the API, but am not including that yet both for the sake of scope and because it depends on unmerged service-side changes.

Issue #6 Proof of concept authentication via Keycloak