### PR TITLE
Create Proposal Detail stub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Header } from './components/Header';
 import { NotFound } from './pages/NotFound';
+import { GetProposal } from './pages/GetProposal';
 import { Placeholder } from './pages/Placeholder';
 import './App.css';
 
@@ -11,6 +12,7 @@ const App = () => (
     <main className="App-main">
       <Routes>
         <Route path="/" element={<Placeholder />} />
+        <Route path="/proposal" element={<GetProposal />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </main>

--- a/src/components/ProposalTable.tsx
+++ b/src/components/ProposalTable.tsx
@@ -1,0 +1,363 @@
+import React from 'react';
+import {
+  Bars3BottomLeftIcon, ChevronDoubleRightIcon, CodeBracketSquareIcon,
+} from '@heroicons/react/24/outline';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  ColumnActions,
+  ColumnAction,
+  TableBody,
+  TableRow,
+  RowHead,
+  RowCell,
+} from './Table';
+
+interface ProposalTableProps {
+  className?: string;
+}
+
+export const ProposalTable = ({
+  className = '',
+}: ProposalTableProps) => (
+  <Table className={className}>
+    <TableHead fixed>
+      <TableRow>
+        <ColumnHead actions>
+          Canonical Field
+          <ColumnActions>
+            <ColumnAction>
+              <CodeBracketSquareIcon className="icon" />
+            </ColumnAction>
+            <ColumnAction>
+              <ChevronDoubleRightIcon className="icon" />
+            </ColumnAction>
+          </ColumnActions>
+        </ColumnHead>
+        <ColumnHead actions>
+          Version 4
+          <ColumnActions>
+            <ColumnAction>
+              <Bars3BottomLeftIcon className="icon" />
+            </ColumnAction>
+          </ColumnActions>
+        </ColumnHead>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+      <TableRow>
+        <RowHead>
+          Proposal Date
+        </RowHead>
+        <RowCell>
+          2023-01-20
+        </RowCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+);

--- a/src/pages/GetProposal.tsx
+++ b/src/pages/GetProposal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { ArrowsRightLeftIcon, UsersIcon } from '@heroicons/react/24/solid';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
+import {
+  Panel,
+  PanelHeader,
+  PanelActions,
+  PanelTitleWrapper,
+  PanelTitle,
+  PanelTitleTags,
+  PanelTag,
+  PanelBody,
+} from '../components/Panel';
+import { Button } from '../components/Button';
+import { ProposalTable } from '../components/ProposalTable';
+
+const GetProposal = () => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        <PanelTitle>[Proposal Title]</PanelTitle>
+        <PanelTitleTags>
+          <PanelTag>
+            <UsersIcon className="icon" />
+            [Organization Name] ([EIN])
+          </PanelTag>
+          <PanelTag>
+            <ArrowsRightLeftIcon className="icon" />
+            [Data Source]
+          </PanelTag>
+        </PanelTitleTags>
+      </PanelTitleWrapper>
+      <PanelActions>
+        <Button>
+          <RectangleStackIcon className="icon" />
+          History
+        </Button>
+      </PanelActions>
+    </PanelHeader>
+    <PanelBody>
+      <ProposalTable />
+    </PanelBody>
+  </Panel>
+);
+
+export { GetProposal };

--- a/src/stories/ProposalTable.stories.tsx
+++ b/src/stories/ProposalTable.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ProposalTable } from '../components/ProposalTable';
+
+const meta = {
+  component: ProposalTable,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProposalTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
_This PR ladders off #43, which ladders off #42. It is expected that #42 and #43 will be merged into their bases before this one is._

This PR adds a very early but functional version of the Proposal Detail page that can be wired up to the API. It adds two things:

- A `ProposalTable` component that combines the `Table` components from #43 into a coherent interface (with some bugs and limitations that will be addressed). This also includes a Storybook story, but it's quite minimal until more functionality is completed.
- A Proposal Detail page (`GetProposal`) that renders the `ProposalTable` into a `Panel`. I imagine @jasonaowen will want to change quite a bit about this page.

<img width="1249" alt="proposal-detail-page" src="https://user-images.githubusercontent.com/4731/226814505-dd8bfcef-cf22-4d98-a5e1-36277a903af2.png">

Issue #19 
