### PR TITLE
Reference: Proposals table list panel and paginator

### DIFF
--- a/src/components/Paginator.css
+++ b/src/components/Paginator.css
@@ -1,0 +1,81 @@
+.paginator-wrapper {
+  /* Cover the entire parent element and don't scroll with it. */
+  position: fixed;
+  inset: var(--fixed-spacing--3x);
+
+  /* But pass all pointer events through to the table behind. */
+  pointer-events: none;
+
+  /* Position the paginator at the bottom center of the body. */
+  display: grid;
+  place-items: end center;
+}
+
+.paginator {
+  --paginator--font-size: 0.875rem;
+  --paginator--min-height: calc(var(--paginator--font-size) * 4);
+  --paginator--border-radius: 9999px;
+
+  --paginator--button-size: var(--paginator--min-height);
+  --paginator--button-icon-size: calc(var(--paginator--button-size) / 2.5);
+
+  /* Re-capture pointer events (clicks, etc.). */
+  pointer-events: auto;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--fixed-spacing--2x);
+
+  overflow: hidden;
+  min-height: var(--paginator--min-height);
+  background-color: white;
+  border-radius: var(--paginator--border-radius);
+  box-shadow: 0 0 3px var(--color--gray--medium);
+
+  font-size: var(--paginator--font-size);
+  line-height: 1;
+}
+
+.paginator-button {
+  all: unset;
+
+  height: var(--paginator--button-size);
+  width: var(--paginator--button-size);
+  border-radius: var(--paginator--border-radius);
+  background-color: var(--color--gray--light);
+  color: var(--color--gray--darker);
+  cursor: pointer;
+
+  display: grid;
+  place-content: center;
+}
+
+.paginator-button .icon {
+  height: var(--paginator--button-icon-size);
+  width: var(--paginator--button-icon-size);
+}
+
+.paginator-button:disabled {
+  color: var(--color--gray--medium);
+  cursor: not-allowed;
+}
+
+.paginator-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--accessible-spacing--halfx);
+  text-align: center;
+
+  text-transform: uppercase;
+}
+
+.paginator-status__value {
+  font-weight: var(--font-weight--medium);
+}
+
+.paginator__page-selector {
+  font-weight: var(--font-weight--medium);
+}

--- a/src/components/Paginator.tsx
+++ b/src/components/Paginator.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/solid';
+import './Paginator.css';
+
+interface PaginatorPage {
+  pageNumber: number,
+  firstItem: number,
+  lastItem: number,
+}
+
+// Utility method that takes the total items and items per page and returns an array
+// of pages with the page number and boundaries.
+const makePages = (totalItems: number, itemsPerPage: number) => {
+  const pages: PaginatorPage[] = [];
+
+  const pageNumbers = Math.ceil(totalItems / itemsPerPage);
+  for (let i = 1; i <= pageNumbers; i += 1) {
+    const previousPageEnd = (i - 1) * itemsPerPage;
+    pages.push({
+      pageNumber: i,
+      firstItem: previousPageEnd + 1,
+      lastItem: Math.min(i * itemsPerPage, totalItems),
+    });
+  }
+
+  return pages;
+};
+
+// Utility method that takes a `PaginatorPage` and returns a range string,
+// e.g. "1–100" or "201–300". If the range is just a single value, returns just that.
+function formatPageBoundaries(page: PaginatorPage) {
+  if (page.firstItem === page.lastItem) {
+    return page.firstItem.toLocaleString();
+  }
+
+  return `${page.firstItem.toLocaleString()}–${page.lastItem.toLocaleString()}`;
+}
+
+interface PaginatorButtonProps {
+  direction: 'previous' | 'next',
+  onClick: () => void;
+  disabled?: boolean,
+}
+
+const PaginatorButton = ({
+  direction,
+  onClick,
+  disabled = false,
+}: PaginatorButtonProps) => (
+  <button
+    className="paginator-button"
+    disabled={disabled}
+    onClick={onClick}
+    type="button"
+  >
+    {direction === 'previous'
+      ? <ArrowLeftIcon className="icon" />
+      : <ArrowRightIcon className="icon" />}
+  </button>
+);
+
+interface PaginatorProps {
+  itemsPerPage: number,
+  totalItems: number,
+  /**
+   * Externally-managed current page.
+   * Note that there is no protection against this being set
+   * to a value larger than `totalItems / itemsPerPage`.
+   */
+  currentPage: number,
+  /**
+   * Function that will update the `currentPage`.
+   * Assumed to be a state hook, but not required.
+   * All that's required is that the external component
+   * change the `currentPage` property above.
+   */
+  setCurrentPage: (page: number) => void,
+}
+
+/**
+ * A component for navigating between pages of a set of items.
+ * Calculates the number of pages and the range start/end values
+ * based on the `totalItems` and `itemsPerPage` props.
+ * Note that "current page" state should be managed externally,
+ * so changing the `currentPage` prop internally has no effect.
+ */
+export const Paginator = ({
+  itemsPerPage,
+  totalItems,
+  currentPage,
+  setCurrentPage,
+}: PaginatorProps) => {
+  const pages = makePages(totalItems, itemsPerPage);
+
+  const totalPages = pages.length;
+
+  const goToPreviousPage = () => {
+    setCurrentPage(Math.min(totalPages, Math.max(1, currentPage - 1)));
+  };
+
+  const goToNextPage = () => {
+    setCurrentPage(Math.max(1, Math.min(totalPages, currentPage + 1)));
+  };
+
+  const handleSelectorChange = (event: React.FormEvent) => {
+    const selector = event.currentTarget as HTMLSelectElement;
+    setCurrentPage(Number(selector.value));
+  };
+
+  return (
+    <div className="paginator">
+      <PaginatorButton
+        direction="previous"
+        onClick={goToPreviousPage}
+        disabled={currentPage <= 1}
+      />
+      <div className="paginator-content">
+        <div className="paginator-status">
+          {'Showing '}
+          {totalPages > 1 ? (
+            <select
+              onChange={handleSelectorChange}
+              value={currentPage}
+              className="paginator__page-selector"
+            >
+              {pages.map((page) => (
+                <option
+                  key={page.pageNumber}
+                  value={page.pageNumber}
+                >
+                  {formatPageBoundaries(page)}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="paginator-status__value">
+              {formatPageBoundaries(pages[0])}
+            </span>
+          )}
+          {' of '}
+          <span className="paginator-status__value">
+            {totalItems.toLocaleString()}
+          </span>
+        </div>
+      </div>
+      <PaginatorButton
+        direction="next"
+        onClick={goToNextPage}
+        disabled={currentPage >= totalPages}
+      />
+    </div>
+  );
+};

--- a/src/components/PaginatorWrapper.tsx
+++ b/src/components/PaginatorWrapper.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface PaginatorWrapperProps {
+  children: React.ReactNode;
+}
+
+export const PaginatorWrapper = ({
+  children,
+}: PaginatorWrapperProps) => (
+  <div className="paginator-wrapper">
+    {children}
+  </div>
+);

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  TableBody,
+  TableRow,
+  RowCell,
+} from './Table';
+
+interface ProposalListTableRowProps {
+  proposal: Record<string, string[]>,
+  proposalId: string,
+  columns: string[],
+}
+
+const ProposalListTableRow = ({
+  proposal,
+  proposalId,
+  columns,
+}: ProposalListTableRowProps) => {
+  const handleRowClick = () => {
+    // TODO: Replace this with a navigation to the proposal detail page.
+    // eslint-disable-next-line no-console
+    console.log(`Navigate to proposal detail page for ${proposalId}`);
+  };
+
+  return (
+    <TableRow onClick={handleRowClick}>
+      {/* Iterate over columns to ensure order. */}
+      {columns.map((shortCode) => (
+        <RowCell key={shortCode}>
+          {proposal[shortCode]}
+        </RowCell>
+      ))}
+    </TableRow>
+  );
+};
+
+interface ProposalListTableProps {
+  proposals: Record<string, string[]>[],
+  fieldNames: Record<string, string>,
+  columns: string[],
+}
+
+export const ProposalListTable = ({
+  fieldNames,
+  proposals,
+  columns,
+}: ProposalListTableProps) => (
+  <Table>
+    <TableHead fixed>
+      <TableRow>
+        {columns.map((shortCode) => (
+          <ColumnHead key={shortCode}>
+            {fieldNames[shortCode]}
+          </ColumnHead>
+        ))}
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {/*
+        FIXME: `proposal.id` is a guess at the field name for the proposal ID.
+               Also, note that it is assumed to be an array like all other proposal values,
+               but if we special-case `id` somehow we'll need to modify the type definition
+               and I, for one, don't know how.
+      */}
+      {proposals.map((proposal) => (proposal.id.length ? (
+        <ProposalListTableRow
+          key={proposal.id.join()}
+          proposalId={proposal.id.join()}
+          columns={columns}
+          proposal={proposal}
+        />
+      ) : null))}
+    </TableBody>
+  </Table>
+);

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Panel,
+  PanelHeader,
+  PanelBody,
+  PanelTitle,
+  PanelTitleWrapper,
+} from './Panel';
+import { ProposalListTable } from './ProposalListTable';
+
+interface ProposalListTablePanelProps {
+  fieldNames: Record<string, string>,
+  proposals: Record<string, string[]>[],
+}
+
+// For now, we are hard-coding this list.
+// In the future, this will be user-configurable.
+// FIXME: The values I'm providing below are completely made up
+//        and should be replaced with real desired fields.
+//        Note that we should update the stories accordingly.
+const DEFAULT_COLUMNS = [
+  'organization_ein',
+  'organization_name',
+  'organization_state',
+  'proposal_date',
+  'proposal_name',
+  'proposal_budget',
+  'proposal_type',
+];
+
+export const ProposalListTablePanel = ({
+  fieldNames,
+  proposals,
+}: ProposalListTablePanelProps) => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        <PanelTitle>Proposals</PanelTitle>
+      </PanelTitleWrapper>
+    </PanelHeader>
+    <PanelBody>
+      <ProposalListTable
+        fieldNames={fieldNames}
+        proposals={proposals}
+        columns={DEFAULT_COLUMNS}
+      />
+    </PanelBody>
+  </Panel>
+);

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -20,10 +20,7 @@
 .table th,
 .table td {
   text-align: left;
-  padding: var(--accessible-spacing--1x)
-    var(--accessible-spacing--1x)
-    var(--accessible-spacing--1x)
-    var(--accessible-spacing--2x);
+  padding: var(--accessible-spacing--1x);
   border-right: 1px solid var(--color--gray--light);
   border-bottom: 1px solid var(--color--gray--light);
 }

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -25,15 +25,17 @@
   border-bottom: 1px solid var(--color--gray--light);
 }
 
-.table tbody tr:last-child th,
-.table tbody tr:last-child td {
-  border-bottom: 1px solid var(--color--gray--medium);
-}
-
+/* The last column should stretch to the table edge and have no right border. */
 .table th:last-child,
 .table td:last-child {
   width: 100%;
   border-right: none;
+}
+
+/* The last body row should have no bottom border. */
+.table tbody tr:last-child th,
+.table tbody tr:last-child td {
+  border-bottom: 1px solid var(--color--gray--medium);
 }
 
 .column-actions-wrapper {

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -38,6 +38,15 @@
   border-bottom: 1px solid var(--color--gray--medium);
 }
 
+.table .clickable {
+  cursor: pointer;
+}
+
+.table .clickable:hover {
+  background-color: var(--color--gray--lighter);
+}
+
+
 .column-actions-wrapper {
   display: flex;
   justify-content: space-between;

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -3,13 +3,18 @@ import React from 'react';
 interface TableRowProps {
   children: React.ReactNode;
   className?: string;
+  onClick?: () => void;
 }
 
 export const TableRow = ({
   children,
   className = '',
+  onClick = undefined,
 }: TableRowProps) => (
-  <tr className={className}>
+  <tr
+    className={`${className} ${onClick ? 'clickable' : ''}`.trim()}
+    onClick={onClick}
+  >
     {children}
   </tr>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -20,11 +20,15 @@
   /* These spacings shouldn't increase with font-size. They have no accessibility impact. */
   --fixed-spacing--1x: 10px;
   --fixed-spacing--2x: calc(2 * var(--fixed-spacing--1x));
+  --fixed-spacing--3x: calc(3 * var(--fixed-spacing--1x));
+  --fixed-spacing--4x: calc(4 * var(--fixed-spacing--1x));
   --fixed-spacing--halfx: calc(var(--fixed-spacing--1x) / 2);
 
   /* These spacings should increase with font-size. They have an accessibility impact. */
   --accessible-spacing--1x: 0.625rem;
   --accessible-spacing--2x: calc(2 * var(--accessible-spacing--1x));
+  --accessible-spacing--3x: calc(3 * var(--accessible-spacing--1x));
+  --accessible-spacing--4x: calc(4 * var(--accessible-spacing--1x));
   --accessible-spacing--halfx: calc(var(--accessible-spacing--1x) / 2);
 
   --transition-duration: 200ms;

--- a/src/stories/Paginator.stories.tsx
+++ b/src/stories/Paginator.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Paginator } from '../components/Paginator';
+
+const meta = {
+  component: Paginator,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Paginator>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    itemsPerPage: 100,
+    totalItems: 950,
+    currentPage: 1,
+    setCurrentPage: () => (false),
+  },
+};

--- a/src/stories/ProposalListTable.stories.tsx
+++ b/src/stories/ProposalListTable.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ProposalListTable } from '../components/ProposalListTable';
+
+const meta = {
+  component: ProposalListTable,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        width: '100%',
+        maxHeight: '400px',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProposalListTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fieldNames: {
+      organization_ein: 'Organization Tax ID',
+      organization_name: 'Organization Name',
+      organization_state: 'Organization State',
+      proposal_date: 'Proposal Date',
+      proposal_name: 'Proposal Name',
+      proposal_budget: 'Proposal Budget',
+      proposal_type: 'Proposal Type',
+    },
+    proposals: [
+      {
+        id: ['1'],
+        organization_ein: ['12-3456789'],
+        organization_name: ['Acme Corp'],
+        organization_state: ['CA'],
+        proposal_date: ['2022-05-01'],
+        proposal_name: ['Make Things Better'],
+        proposal_budget: ['$50,000'],
+        proposal_type: ['Program Expenses'],
+      },
+      {
+        id: ['2'],
+        organization_ein: ['98-7654321'],
+        organization_name: ['XYZ Inc.'],
+        organization_state: ['NY'],
+        proposal_date: ['2023-09-15'],
+        proposal_name: ['Improve The World'],
+        proposal_budget: ['$100,000'],
+        proposal_type: ['Political Advocacy'],
+      },
+    ],
+    columns: [
+      'organization_ein',
+      'organization_name',
+      'organization_state',
+      'proposal_date',
+      'proposal_name',
+      'proposal_budget',
+      'proposal_type',
+    ],
+  },
+};

--- a/src/stories/ProposalListTablePanel.stories.tsx
+++ b/src/stories/ProposalListTablePanel.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
+
+const meta = {
+  component: ProposalListTablePanel,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        width: '100%',
+        height: '400px',
+        position: 'relative',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProposalListTablePanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fieldNames: {
+      organization_ein: 'Organization Tax ID',
+      organization_name: 'Organization Name',
+      organization_state: 'Organization State',
+      proposal_date: 'Proposal Date',
+      proposal_name: 'Proposal Name',
+      proposal_budget: 'Proposal Budget',
+      proposal_type: 'Proposal Type',
+    },
+    proposals: [
+      {
+        id: ['1'],
+        organization_ein: ['12-3456789'],
+        organization_name: ['Acme Corp'],
+        organization_state: ['CA'],
+        proposal_date: ['2022-05-01'],
+        proposal_name: ['Make Things Better'],
+        proposal_budget: ['$50,000'],
+        proposal_type: ['Program Expenses'],
+      },
+      {
+        id: ['2'],
+        organization_ein: ['98-7654321'],
+        organization_name: ['XYZ Inc.'],
+        organization_state: ['NY'],
+        proposal_date: ['2021-09-15'],
+        proposal_name: ['Improve The World'],
+        proposal_budget: ['$100,000'],
+        proposal_type: ['Political Advocacy'],
+      },
+      {
+        id: ['3'],
+        organization_ein: ['23-4567891'],
+        organization_name: ['Globex Corporation'],
+        organization_state: ['TX'],
+        proposal_date: ['2022-12-31'],
+        proposal_name: ['Expand Our Reach'],
+        proposal_budget: ['$75,000'],
+        proposal_type: ['Capacity Building'],
+      },
+      {
+        id: ['4'],
+        organization_ein: ['12-3456789'],
+        organization_name: ['Acme Corp'],
+        organization_state: ['CA'],
+        proposal_date: ['2022-07-15'],
+        proposal_name: ['Upgrade Our Systems'],
+        proposal_budget: ['$200,000'],
+        proposal_type: ['Research and Development'],
+      },
+      {
+        id: ['5'],
+        organization_ein: ['11-2233445'],
+        organization_name: ['Stark Industries'],
+        organization_state: ['NY'],
+        proposal_date: ['2022-01-01'],
+        proposal_name: ['Save The Planet'],
+        proposal_budget: ['$500,000'],
+        proposal_type: ['Environmental Protection'],
+      },
+      {
+        id: ['6'],
+        organization_ein: ['98-7654321'],
+        organization_name: ['XYZ Inc.'],
+        organization_state: ['NY'],
+        proposal_date: ['2023-03-15'],
+        proposal_name: ['Empower The Youth'],
+        proposal_budget: ['$80,000'],
+        proposal_type: ['Capacity Building'],
+      },
+      {
+        id: ['7'],
+        organization_ein: ['34-5678901'],
+        organization_name: ['Genco Pura Olive Oil Company'],
+        organization_state: ['NJ'],
+        proposal_date: ['2022-10-01'],
+        proposal_name: ['Promote Healthy Living'],
+        proposal_budget: ['$150,000'],
+        proposal_type: ['Community Outreach'],
+      },
+      {
+        id: ['8'],
+        organization_ein: ['99-8765432'],
+        organization_name: ['Wayne Enterprises'],
+        organization_state: ['NJ'],
+        proposal_date: ['2021-04-15'],
+        proposal_name: ['Fight Crime'],
+        proposal_budget: ['$250,000'],
+        proposal_type: ['Law Enforcement'],
+      },
+      {
+        id: ['9'],
+        organization_ein: ['34-5678901'],
+        organization_name: ['Genco Pura Olive Oil Company'],
+        organization_state: ['NJ'],
+        proposal_date: ['2022-01-01'],
+        proposal_name: ['Reduce Carbon Footprint'],
+        proposal_budget: ['$400,000'],
+        proposal_type: ['Environmental Protection'],
+      },
+      {
+        id: ['10'],
+        organization_ein: ['23-4567891'],
+        organization_name: ['Globex Corporation'],
+        organization_state: ['TX'],
+        proposal_date: ['2022-11-01'],
+        proposal_name: ['Innovate and Grow'],
+        proposal_budget: ['$300,000'],
+        proposal_type: ['Research and Development'],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This PR is really too large and may be considered a WIP for plucking and restructuring. It also slips in the Paginator component and its story, but stops short of showing how to use it.

Notes:
- `ProposalListTablePanel` is the primary component which will be dropped onto the new proposals table page itself. It has its own story so you can see how it renders.
   - In the current iteration, there are no buttons in the panel header, because all that functionality (filtering, searching, columns) will come in future work. So for now, it just has a title.
- `ProposalListTable` is the main component that drives `ProposalListTablePanel`. Right now there's some redundancy between them, but I expect that will reduce as we feed it with real data. Or, maybe not!
- `Paginator` is here! I'm taking a bit of a stab at how we want to structure this, but I think it's correct: pagination is generated programmatically based on the number of total items and the number of items per page. "Current page" is assumed to be set in state outside of the paginator itself and passed in via a prop, which means we also need to pass in the state-updating method. Or maybe there's another way of doing that these days, I can't recall if the data store is universal (ala Redux) or not, but I don't think so?
- This commit adds the ability to click on a row and go somewhere. Right now, it just `console.log`s, because I'm not sure what the path to the detail page will be.
- Relatedly, I'm completely guessing that we'll have a stable proposal ID (as in, internal to the PDC) on each `proposal` object, and am guessing its fieldName will be `"id"`. We can change.

**Testing paginator:** In `ProposalListTablePanel.tsx`, add the paginator to the `<PanelBody>` so that it looks like so:

```html
<PanelBody>
  <PaginatorWrapper>
    <Paginator
      itemsPerPage={100}
      totalItems={950}
      currentPage={1}
      setCurrentPage={(page) => { console.log(page); }}
    />
  </PaginatorWrapper>
  <ProposalListTable
    fields={fields}
    proposals={proposals}
  />
</PanelBody>
```

Here's how the `ProposalListTablePanel` story would look if you made that change:
<img width="980" alt="Screenshot of a proposal list table panel" src="https://user-images.githubusercontent.com/4731/228970629-80c7e860-6cfd-448b-ba79-547c1e436cc9.png">

Affects #14 
Affects #15