### PR TITLE
Show proposal details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ REACT_APP_OIDC_AUTHORITY=https://auth.example.com/realms/example
 
 # The client ID is assigned by the IdP
 REACT_APP_OIDC_CLIENT_ID=example-data-viewer
+
+# The API URL is the location of a running PhilanthropyDataCommons/service instance
+# https://github.com/PhilanthropyDataCommons/service
+REACT_APP_API_URL=https://api.example.com

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Philanthropy Data Commons Data Viewer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Header } from './components/Header';
 import { NotFound } from './pages/NotFound';
+import { ProposalDetail } from './pages/ProposalDetail';
 import { Placeholder } from './pages/Placeholder';
 import './App.css';
 
@@ -11,6 +12,7 @@ const App = () => (
     <main className="App-main">
       <Routes>
         <Route path="/" element={<Placeholder />} />
+        <Route path="/proposal/:proposalId" element={<ProposalDetail />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </main>

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -61,6 +61,10 @@
   height: var(--icon-size--text);
 }
 
+.panel-tag .badge {
+  --badge--background-color: var(--color--gray--medium);
+}
+
 .panel-actions {
   display: flex;
   gap: var(--fixed-spacing--1x);

--- a/src/components/Panel/PanelTag.tsx
+++ b/src/components/Panel/PanelTag.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 
 interface PanelTagProps {
   children: React.ReactNode;
+  icon?: React.ReactElement | null;
   className?: string;
 }
 
 export const PanelTag = ({
   children,
+  icon = undefined,
   className = '',
 }: PanelTagProps) => (
   <div className={`panel-tag ${className}`.trim()}>
+    {icon ? React.cloneElement(icon, { className: 'icon' }) : null}
     {children}
   </div>
 );

--- a/src/components/Panel/PanelTag.tsx
+++ b/src/components/Panel/PanelTag.tsx
@@ -3,16 +3,19 @@ import React from 'react';
 interface PanelTagProps {
   children: React.ReactNode;
   icon?: React.ReactElement | null;
+  badge?: string | null;
   className?: string;
 }
 
 export const PanelTag = ({
   children,
   icon = undefined,
+  badge = undefined,
   className = '',
 }: PanelTagProps) => (
   <div className={`panel-tag ${className}`.trim()}>
     {icon ? React.cloneElement(icon, { className: 'icon' }) : null}
+    {badge ? <span className="badge">{badge}</span> : null}
     {children}
   </div>
 );

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BuildingLibraryIcon, DocumentIcon } from '@heroicons/react/24/solid';
+import { DocumentTextIcon } from '@heroicons/react/24/solid';
 import {
   Panel,
   PanelBody,
@@ -38,7 +38,7 @@ const ProposalDetailPanel = ({
         </PanelTitle>
         <PanelTitleTags>
           {applicantId && (
-            <PanelTag icon={<BuildingLibraryIcon />}>
+            <PanelTag badge="EIN">
               {applicantId}
             </PanelTag>
           )}

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -38,14 +38,12 @@ const ProposalDetailPanel = ({
         </PanelTitle>
         <PanelTitleTags>
           {applicantId && (
-            <PanelTag>
-              <BuildingLibraryIcon className="icon" />
+            <PanelTag icon={<BuildingLibraryIcon />}>
               {applicantId}
             </PanelTag>
           )}
           {title && (
-            <PanelTag>
-              <DocumentIcon className="icon" />
+            <PanelTag icon={<DocumentTextIcon />}>
               {title}
             </PanelTag>
           )}

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { BuildingLibraryIcon, DocumentIcon } from '@heroicons/react/24/solid';
+import {
+  Panel,
+  PanelBody,
+  PanelHeader,
+  PanelTag,
+  PanelTitle,
+  PanelTitleTags,
+  PanelTitleWrapper,
+} from './Panel';
+import { ProposalTable } from './ProposalTable';
+
+interface ProposalDetailPanelProps {
+  title: string | undefined;
+  applicant: string;
+  applicantId: string | undefined;
+  version: number;
+  values: {
+    fieldName: string,
+    position: number,
+    value: string,
+  }[],
+}
+
+const ProposalDetailPanel = ({
+  title,
+  applicant,
+  applicantId,
+  version,
+  values,
+}: ProposalDetailPanelProps) => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        <PanelTitle>
+          {applicant}
+        </PanelTitle>
+        <PanelTitleTags>
+          {applicantId && (
+            <PanelTag>
+              <BuildingLibraryIcon className="icon" />
+              {applicantId}
+            </PanelTag>
+          )}
+          {title && (
+            <PanelTag>
+              <DocumentIcon className="icon" />
+              {title}
+            </PanelTag>
+          )}
+        </PanelTitleTags>
+      </PanelTitleWrapper>
+    </PanelHeader>
+    <PanelBody>
+      <ProposalTable
+        version={version}
+        values={values}
+      />
+    </PanelBody>
+  </Panel>
+);
+
+export { ProposalDetailPanel };

--- a/src/components/ProposalTable.tsx
+++ b/src/components/ProposalTable.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  TableBody,
+  TableRow,
+  RowHead,
+  RowCell,
+} from './Table';
+
+interface ProposalTableProps {
+  version: number;
+  values: {
+    fieldName: string,
+    position: number,
+    value: string,
+  }[],
+}
+
+export const ProposalTable = ({
+  values,
+  version,
+}: ProposalTableProps) => (
+  <Table>
+    <TableHead fixed>
+      <TableRow>
+        <ColumnHead>
+          Canonical Field
+        </ColumnHead>
+        <ColumnHead>
+          {`Version ${version}`}
+        </ColumnHead>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {values.map(({ fieldName, position, value }) => (
+        <TableRow key={position}>
+          <RowHead>
+            {fieldName}
+          </RowHead>
+          <RowCell>
+            {value}
+          </RowCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -17,6 +17,10 @@
   white-space: nowrap;
 }
 
+.table tbody th {
+  white-space: nowrap;
+}
+
 .table th,
 .table td {
   text-align: left;

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,9 @@
   --transition-duration: 200ms;
 
   --icon-size--text: 1.25em;
+
+  --badge--background-color: var(--color--gray--darker);
+  --badge--color: white;
 }
 
 body {
@@ -77,4 +80,12 @@ h6 {
   padding: 0;
   font-weight: var(--font-weight--normal);
   line-height: 1.2;
+}
+
+.badge {
+  background-color: var(--badge--background-color);
+  color: var(--badge--color);
+  font-size: 0.8em;
+  padding: 0 0.25em;
+  border-radius: 2px;
 }

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { OidcSecure } from '@axa-fr/react-oidc';
 import { useParams } from 'react-router-dom';
 import {
@@ -39,11 +39,33 @@ const mapCanonicalFields = (
   }))
 );
 
+const getApplicant = (
+  canonicalFields: CanonicalField[],
+  proposal: Proposal,
+) => (
+  getValueOfCanonicalField(canonicalFields, proposal, 'organization_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_dba_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_legal_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_primary_contact_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_submitter_name')
+    ?? 'Unknown Applicant'
+);
+
 const ProposalDetail = () => {
   const params = useParams();
   const proposalId = params.proposalId ?? 'missing';
   const canonicalFields = useCanonicalFields();
   const proposal = useProposal(proposalId);
+
+  useEffect(() => {
+    if (canonicalFields === null || proposal === null) {
+      document.title = 'Proposal Detail - Philanthropy Data Commons';
+    } else {
+      const applicant = getApplicant(canonicalFields, proposal);
+      document.title = `${applicant} Proposal Detail - Philanthropy Data Commons`;
+    }
+    return () => { document.title = 'Philanthropy Data Commons'; };
+  }, [canonicalFields, proposal]);
 
   if (canonicalFields === null || proposal === null) {
     return (
@@ -61,12 +83,7 @@ const ProposalDetail = () => {
 
   const title = getValueOfCanonicalField(canonicalFields, proposal, 'proposal_name')
     ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_title');
-  const applicant = getValueOfCanonicalField(canonicalFields, proposal, 'organization_name')
-    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_dba_name')
-    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_legal_name')
-    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_primary_contact_name')
-    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_submitter_name')
-    ?? 'Unknown Applicant';
+  const applicant = getApplicant(canonicalFields, proposal);
   const applicantId = getValueOfCanonicalField(canonicalFields, proposal, 'organization_tax_id');
   const { version } = proposal.versions[0];
   const values = mapCanonicalFields(canonicalFields, proposal);

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { OidcSecure } from '@axa-fr/react-oidc';
+import { useParams } from 'react-router-dom';
+import {
+  CanonicalField,
+  Proposal,
+  useCanonicalFields,
+  useProposal,
+} from '../pdc-api';
+import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
+
+const getValueOfCanonicalField = (
+  canonicalFields: CanonicalField[],
+  proposal: Proposal,
+  canonicalFieldShortCode: string,
+) => {
+  const field = canonicalFields.find(({ shortCode }) => (
+    shortCode === canonicalFieldShortCode
+  ));
+  if (field === undefined) {
+    return undefined;
+  }
+  const fieldValue = proposal.versions[0].fieldValues.find(({ applicationFormField }) => (
+    applicationFormField.canonicalFieldId === field.id
+  ));
+  return fieldValue?.value ?? undefined;
+};
+
+const mapCanonicalFields = (
+  canonicalFields: CanonicalField[],
+  proposal: Proposal,
+) => (
+  proposal.versions[0].fieldValues.map(({ applicationFormField, value }) => ({
+    fieldName: canonicalFields.find(({ id }) => (
+      id === applicationFormField.canonicalFieldId
+    ))?.label ?? 'missing',
+    position: applicationFormField.position,
+    value,
+  }))
+);
+
+const ProposalDetail = () => {
+  const params = useParams();
+  const proposalId = params.proposalId ?? 'missing';
+  const canonicalFields = useCanonicalFields();
+  const proposal = useProposal(proposalId);
+
+  if (canonicalFields === null || proposal === null) {
+    return (
+      <OidcSecure>
+        <ProposalDetailPanel
+          title="Loading..."
+          applicant="Loading..."
+          applicantId="00-0000000"
+          version={0}
+          values={[]}
+        />
+      </OidcSecure>
+    );
+  }
+
+  const title = getValueOfCanonicalField(canonicalFields, proposal, 'proposal_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_title');
+  const applicant = getValueOfCanonicalField(canonicalFields, proposal, 'organization_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_dba_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_legal_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_primary_contact_name')
+    ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_submitter_name')
+    ?? 'Unknown Applicant';
+  const applicantId = getValueOfCanonicalField(canonicalFields, proposal, 'organization_tax_id');
+  const { version } = proposal.versions[0];
+  const values = mapCanonicalFields(canonicalFields, proposal);
+
+  return (
+    <OidcSecure>
+      <ProposalDetailPanel
+        title={title}
+        applicant={applicant}
+        applicantId={applicantId}
+        version={version}
+        values={values}
+      />
+    </OidcSecure>
+  );
+};
+
+export { ProposalDetail };

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useOidcFetch } from '@axa-fr/react-oidc';
+import { getLogger } from './logger';
+
+const logger = getLogger('pdc-api');
+
+const API_URL = process.env.REACT_APP_API_URL;
+
+// Custom React hook to make authenticated requests to the configured API
+const usePdcApi = <T>(path: string): T | null => {
+  const { fetch } = useOidcFetch();
+  const [response, setResponse] = useState(null);
+
+  useEffect(() => {
+    fetch(new URL(path, API_URL))
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Response status: ${res.status} ${res.statusText}`);
+        }
+        return res;
+      })
+      .then((res) => res.json())
+      .then(setResponse)
+      .catch((error: unknown) => logger.error({ error }, `Error fetching ${path}`));
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps --
+     * fetch should not be a dependency, because although it or its internal
+     * state may change from render to render, such changes are not relevant:
+     * a change in the way we make a request should not trigger an API request
+     */
+  }, [path]);
+
+  return response;
+};
+
+interface CanonicalField {
+  id: number;
+  label: string;
+  shortCode: string;
+}
+
+const useCanonicalFields = () => usePdcApi<CanonicalField[]>('/canonicalFields');
+
+interface Proposal {
+  versions: {
+    version: number;
+    fieldValues: {
+      applicationFormField: {
+        canonicalFieldId: number;
+        position: number;
+      };
+      value: string;
+    }[];
+  }[];
+}
+
+const useProposal = (proposalId: string) => (
+  usePdcApi<Proposal>(`/proposals/${proposalId}?includeFieldsAndValues=true`)
+);
+
+export {
+  useCanonicalFields,
+  usePdcApi,
+  useProposal,
+};
+
+export type {
+  CanonicalField,
+  Proposal,
+};

--- a/src/stories/ProposalDetail.stories.tsx
+++ b/src/stories/ProposalDetail.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
+
+const meta = {
+  component: ProposalDetailPanel,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProposalDetailPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Proposal Title',
+    applicant: 'Organization Name',
+    applicantId: '12-3456789',
+    version: 1,
+    values: [
+      { fieldName: 'Proposal Date', position: 1, value: '2023-01-20' },
+    ],
+  },
+};

--- a/src/stories/ProposalTable.stories.tsx
+++ b/src/stories/ProposalTable.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ProposalTable } from '../components/ProposalTable';
+
+const meta = {
+  component: ProposalTable,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProposalTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    version: 1,
+    values: [
+      { fieldName: 'Proposal Date', position: 1, value: '2023-01-20' },
+    ],
+  },
+};


### PR DESCRIPTION
Add a new proposal detail page at `/proposal/:proposalId` that will fetch and display the details of the most recent version of that proposal. Visiting that page will automatically start the log in process if you are not yet logged in.

This is the first example of a pattern I'm proposing of separating display components (such as `<ProposalDetailPanel>`) from logic components that make API requests, transform API responses into the format display components expect, and so on. This separation will, I hope, make it easier to prototype new components, play with components in the storybook, and disentangle display logic from business logic. (This PR does not introduce any display logic, but an example would be the button that toggles between showing canonical field names and short codes; I'd expect the display components to accept all the data they'd need, and then internally decide what to display.)

Note that to use this locally, you will need to define the new `REACT_APP_API_URL` environment variable.

This draws heavily from PR #44, but leaves some things behind (such as buttons that are not yet implemented) and adds functionality.