### PR TITLE
Proposal list page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 import type { Preview } from "@storybook/react";
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import '@fontsource/source-sans-pro/400.css';
 import '@fontsource/source-sans-pro/600.css';
 import '@fontsource/source-sans-pro/700.css';
@@ -17,6 +19,13 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    )
+  ]
 };
 
 export default preview;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import { Header } from './components/Header';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
+import { ProposalList } from './pages/ProposalList';
 import { Placeholder } from './pages/Placeholder';
 import './App.css';
 
@@ -13,6 +14,7 @@ const App = () => (
       <Routes>
         <Route path="/" element={<Placeholder />} />
         <Route path="/proposal/:proposalId" element={<ProposalDetail />} />
+        <Route path="/proposals" element={<ProposalList />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </main>

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -1,6 +1,7 @@
 :root {
   --button--focus-color: blue;
   --button--font-size: 1rem;
+  --button--border-radius: 8px;
   /* These next values should be relative to the button's font-size, so we switch to `em` units. */
   --button--height: 2.75em;
   --button--icon-size: 1.5em;
@@ -17,7 +18,7 @@
   box-sizing: border-box;
   cursor: pointer;
 
-  border-radius: 8px;
+  border-radius: var(--button--border-radius);
   border: 1px solid transparent;
   font-family: var(--font-family--sans-serif);
   font-weight: var(--font-weight--medium);

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { HomeIcon } from '@heroicons/react/24/solid';
 import { EnvelopeIcon } from '@heroicons/react/24/outline';
+import { TableCellsIcon } from '@heroicons/react/24/solid';
 import { User } from './User';
 
 const Navbar = () => (
   <nav className="App-navbar">
     <ul>
       <li>
-        <NavLink to="/" className="App-navbar__item">
-          <HomeIcon />
-          Home
+        <NavLink to="/proposals" className="App-navbar__item">
+          <TableCellsIcon />
+          Dashboard
         </NavLink>
       </li>
       <li>

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  TableBody,
+  TableRow,
+  RowCell,
+} from './Table';
+
+interface ProposalListTableRowProps {
+  columns: string[];
+  proposal: {
+    id: string;
+    values: Record<string, string[]>;
+  };
+}
+
+const ProposalListTableRow = ({
+  proposal,
+  columns,
+}: ProposalListTableRowProps) => {
+  const navigate = useNavigate();
+
+  const handleRowClick = () => {
+    navigate(`/proposal/${proposal.id}`);
+  };
+
+  return (
+    <TableRow onClick={handleRowClick}>
+      {/* Iterate over columns to ensure order. */}
+      {columns.map((shortCode) => (
+        <RowCell key={shortCode}>
+          {proposal.values[shortCode]}
+        </RowCell>
+      ))}
+    </TableRow>
+  );
+};
+
+interface ProposalListTableProps {
+  columns: string[];
+  fieldNames: Record<string, string>;
+  proposals: {
+    id: string;
+    values: Record<string, string[]>;
+  }[];
+}
+
+export const ProposalListTable = ({
+  fieldNames,
+  proposals,
+  columns,
+}: ProposalListTableProps) => (
+  <Table>
+    <TableHead fixed>
+      <TableRow>
+        {columns.map((shortCode) => (
+          <ColumnHead key={shortCode}>
+            {fieldNames[shortCode]}
+          </ColumnHead>
+        ))}
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {proposals.map((proposal, index) => (
+        <ProposalListTableRow
+          key={index} // eslint-disable-line react/no-array-index-key
+          columns={columns}
+          proposal={proposal}
+        />
+      ))}
+    </TableBody>
+  </Table>
+);

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -46,14 +46,16 @@ interface ProposalListTableProps {
     id: string;
     values: Record<string, string[]>;
   }[];
+  wrap?: boolean;
 }
 
 export const ProposalListTable = ({
   fieldNames,
   proposals,
   columns,
+  wrap = false,
 }: ProposalListTableProps) => (
-  <Table>
+  <Table truncate={!wrap}>
     <TableHead fixed>
       <TableRow>
         {columns.map((shortCode) => (

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -3,10 +3,10 @@ import {
   Panel,
   PanelHeader,
   PanelBody,
-  PanelTitle,
-  PanelTitleWrapper,
+  PanelActions,
 } from './Panel';
 import { ProposalListTable } from './ProposalListTable';
+import { Button } from './Button';
 
 interface ProposalListTablePanelProps {
   fieldNames: Record<string, string>;
@@ -44,9 +44,16 @@ export const ProposalListTablePanel = ({
 }: ProposalListTablePanelProps) => (
   <Panel>
     <PanelHeader>
-      <PanelTitleWrapper>
-        <PanelTitle>Proposals</PanelTitle>
-      </PanelTitleWrapper>
+      <PanelActions>
+        <input
+          type="text"
+          placeholder="Text to search for…"
+          className="input"
+        />
+        <Button disabled>
+          Search
+        </Button>
+      </PanelActions>
     </PanelHeader>
     <PanelBody>
       <ProposalListTable

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Panel,
+  PanelHeader,
+  PanelBody,
+  PanelTitle,
+  PanelTitleWrapper,
+} from './Panel';
+import { ProposalListTable } from './ProposalListTable';
+
+interface ProposalListTablePanelProps {
+  fieldNames: Record<string, string>;
+  proposals: {
+    id: string;
+    values: Record<string, string[]>;
+  }[];
+}
+
+// For now, we are hard-coding this list.
+// In the future, this will be user-configurable.
+const DEFAULT_COLUMNS = [
+  'organization_name',
+  'organization_tax_id',
+  'organization_city',
+  'organization_state_province',
+  'organization_country',
+  'organization_website',
+  // 'organization_mission_statement', // FIXME: Disabled until we have wrap
+  'organization_start_date',
+  'organization_operating_budget',
+  'proposal_title',
+  'proposal_summary',
+  'proposal_amount_requested',
+  'proposal_budget',
+  'proposal_fiscal_sponsor_name',
+  'proposal_start_date',
+  'proposal_end_date',
+  'proposal_location_of_work',
+];
+
+export const ProposalListTablePanel = ({
+  fieldNames,
+  proposals,
+}: ProposalListTablePanelProps) => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        <PanelTitle>Proposals</PanelTitle>
+      </PanelTitleWrapper>
+    </PanelHeader>
+    <PanelBody>
+      <ProposalListTable
+        fieldNames={fieldNames}
+        proposals={proposals}
+        columns={DEFAULT_COLUMNS}
+      />
+    </PanelBody>
+  </Panel>
+);

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
 import {
   Panel,
   PanelHeader,
@@ -25,7 +26,7 @@ const DEFAULT_COLUMNS = [
   'organization_state_province',
   'organization_country',
   'organization_website',
-  // 'organization_mission_statement', // FIXME: Disabled until we have wrap
+  'organization_mission_statement',
   'organization_start_date',
   'organization_operating_budget',
   'proposal_title',
@@ -41,26 +42,42 @@ const DEFAULT_COLUMNS = [
 export const ProposalListTablePanel = ({
   fieldNames,
   proposals,
-}: ProposalListTablePanelProps) => (
-  <Panel>
-    <PanelHeader>
-      <PanelActions>
-        <input
-          type="text"
-          placeholder="Text to search for…"
-          className="input"
+}: ProposalListTablePanelProps) => {
+  const [wrap, setWrap] = useState(false);
+
+  const handleWrapClick = () => setWrap((previous) => !previous);
+
+  return (
+    <Panel>
+      <PanelHeader>
+        <PanelActions>
+          <input
+            type="text"
+            placeholder="Text to search for…"
+            className="input"
+          />
+          <Button disabled>
+            Search
+          </Button>
+        </PanelActions>
+        <PanelActions>
+          <Button
+            onClick={handleWrapClick}
+            color={wrap ? 'blue' : 'gray'}
+          >
+            <Bars3BottomLeftIcon className="icon" />
+            Toggle wrapping
+          </Button>
+        </PanelActions>
+      </PanelHeader>
+      <PanelBody>
+        <ProposalListTable
+          fieldNames={fieldNames}
+          proposals={proposals}
+          columns={DEFAULT_COLUMNS}
+          wrap={wrap}
         />
-        <Button disabled>
-          Search
-        </Button>
-      </PanelActions>
-    </PanelHeader>
-    <PanelBody>
-      <ProposalListTable
-        fieldNames={fieldNames}
-        proposals={proposals}
-        columns={DEFAULT_COLUMNS}
-      />
-    </PanelBody>
-  </Panel>
-);
+      </PanelBody>
+    </Panel>
+  );
+};

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -14,6 +14,7 @@
 .table thead th {
   border-top: 1px solid var(--color--gray--medium);
   border-bottom: 1px solid var(--color--gray--medium);
+  vertical-align: bottom;
   white-space: nowrap;
 }
 
@@ -40,6 +41,11 @@
 .table tbody tr:last-child th,
 .table tbody tr:last-child td {
   border-bottom: 1px solid var(--color--gray--medium);
+}
+
+.table tbody th,
+.table tbody td {
+  vertical-align: top;
 }
 
 /* Truncated tables don't wrap table body contents. */

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -42,6 +42,14 @@
   border-bottom: 1px solid var(--color--gray--medium);
 }
 
+/* Truncated tables don't wrap table body contents. */
+.table.truncate tbody td {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60ch;
+}
+
 .table .clickable {
   cursor: pointer;
 }

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -29,15 +29,17 @@
   border-bottom: 1px solid var(--color--gray--light);
 }
 
-.table tbody tr:last-child th,
-.table tbody tr:last-child td {
-  border-bottom: 1px solid var(--color--gray--medium);
-}
-
+/* The last column should stretch to the table edge and have no right border. */
 .table th:last-child,
 .table td:last-child {
   width: 100%;
   border-right: none;
+}
+
+/* The last body row should have a darker bottom border. */
+.table tbody tr:last-child th,
+.table tbody tr:last-child td {
+  border-bottom: 1px solid var(--color--gray--medium);
 }
 
 .table .has-actions .column-head-wrapper {

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -42,6 +42,14 @@
   border-bottom: 1px solid var(--color--gray--medium);
 }
 
+.table .clickable {
+  cursor: pointer;
+}
+
+.table .clickable:hover {
+  background-color: var(--color--gray--lighter);
+}
+
 .table .has-actions .column-head-wrapper {
   display: flex;
   justify-content: space-between;

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -24,10 +24,7 @@
 .table th,
 .table td {
   text-align: left;
-  padding: var(--accessible-spacing--1x)
-    var(--accessible-spacing--1x)
-    var(--accessible-spacing--1x)
-    var(--accessible-spacing--2x);
+  padding: var(--accessible-spacing--1x);
   border-right: 1px solid var(--color--gray--light);
   border-bottom: 1px solid var(--color--gray--light);
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -4,13 +4,24 @@ import './Table.css';
 interface TableProps {
   children: React.ReactNode;
   className?: string;
+  /**
+   * Table body cells won't wrap and will have a max-width,
+   * above which the text will be hidden.
+   */
+  truncate?: boolean;
 }
 
 export const Table = ({
   children,
   className = '',
+  truncate = false,
 }: TableProps) => (
-  <table border={0} cellPadding={0} cellSpacing={0} className={`table ${className}`.trim()}>
+  <table
+    border={0}
+    cellPadding={0}
+    cellSpacing={0}
+    className={`table ${truncate ? 'truncate' : ''} ${className}`.trim()}
+  >
     {children}
   </table>
 );

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -3,13 +3,18 @@ import React from 'react';
 interface TableRowProps {
   children: React.ReactNode;
   className?: string;
+  onClick?: () => void;
 }
 
 export const TableRow = ({
   children,
   className = '',
+  onClick = undefined,
 }: TableRowProps) => (
-  <tr className={className}>
+  <tr
+    className={`${className} ${onClick ? 'clickable' : ''}`.trim()}
+    onClick={onClick}
+  >
     {children}
   </tr>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -97,3 +97,13 @@ code {
   padding: 0 0.25em;
   border-radius: 2px;
 }
+
+.input[type=text] {
+  font-family: var(--font-family--sans-serif);
+  /* TODO: Replace this these references to button vars with form-generic vars. */
+  font-size: var(--button--font-size);
+  height: var(--button--height);
+  padding: var(--button--padding-y) var(--button--padding-x);
+  border-radius: var(--button--border-radius);
+  border: 1px solid var(--color--gray--dark);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -20,11 +20,15 @@
   /* These spacings shouldn't increase with font-size. They have no accessibility impact. */
   --fixed-spacing--1x: 10px;
   --fixed-spacing--2x: calc(2 * var(--fixed-spacing--1x));
+  --fixed-spacing--3x: calc(3 * var(--fixed-spacing--1x));
+  --fixed-spacing--4x: calc(4 * var(--fixed-spacing--1x));
   --fixed-spacing--halfx: calc(var(--fixed-spacing--1x) / 2);
 
   /* These spacings should increase with font-size. They have an accessibility impact. */
   --accessible-spacing--1x: 0.625rem;
   --accessible-spacing--2x: calc(2 * var(--accessible-spacing--1x));
+  --accessible-spacing--3x: calc(3 * var(--accessible-spacing--1x));
+  --accessible-spacing--4x: calc(4 * var(--accessible-spacing--1x));
   --accessible-spacing--halfx: calc(var(--accessible-spacing--1x) / 2);
 
   --transition-duration: 200ms;

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -20,7 +20,7 @@ const getValueOfCanonicalField = (
   if (field === undefined) {
     return undefined;
   }
-  const fieldValue = proposal.versions[0].fieldValues.find(({ applicationFormField }) => (
+  const fieldValue = proposal.versions[0]?.fieldValues.find(({ applicationFormField }) => (
     applicationFormField.canonicalFieldId === field.id
   ));
   return fieldValue?.value ?? undefined;
@@ -30,7 +30,7 @@ const mapCanonicalFields = (
   canonicalFields: CanonicalField[],
   proposal: Proposal,
 ) => (
-  proposal.versions[0].fieldValues.map(({ applicationFormField, value }) => {
+  (proposal.versions[0]?.fieldValues ?? []).map(({ applicationFormField, value }) => {
     const canonicalField = canonicalFields.find(({ id }) => (
       id === applicationFormField.canonicalFieldId
     ));
@@ -90,7 +90,7 @@ const ProposalDetail = () => {
     ?? getValueOfCanonicalField(canonicalFields, proposal, 'proposal_title');
   const applicant = getApplicant(canonicalFields, proposal);
   const applicantId = getValueOfCanonicalField(canonicalFields, proposal, 'organization_tax_id');
-  const { version } = proposal.versions[0];
+  const version = proposal.versions[0]?.version ?? 0;
   const values = mapCanonicalFields(canonicalFields, proposal);
 
   return (

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { OidcSecure } from '@axa-fr/react-oidc';
+import { useSearchParams } from 'react-router-dom';
+import {
+  CanonicalField,
+  Proposal,
+  useCanonicalFields,
+  useProposals,
+} from '../pdc-api';
+import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
+
+const mapFieldNames = (fields: CanonicalField[]) => Object.fromEntries(
+  fields.map(({ label, shortCode }) => [shortCode, label]),
+);
+
+const extendMultimapReducer = (
+  multimap: Record<string, string[]>,
+  [key, value]: [string, string],
+): Record<string, string[]> => ({
+  [key]: (multimap[key] ?? []).concat([value]),
+  ...multimap,
+});
+
+const mapProposals = (fields: CanonicalField[], proposals: Proposal[]) => (
+  proposals.map((proposal: Proposal) => ({
+    id: proposal.id.toString(),
+    values: (
+      (proposal.versions[0]?.fieldValues ?? []).map(({
+        applicationFormField: { canonicalFieldId },
+        value,
+      }) => [
+        fields.find(({ id }) => (id === canonicalFieldId))?.shortCode,
+        value,
+      ])
+        .filter((pair): pair is [string, string] => !!pair[0])
+        .reduce(extendMultimapReducer, {})
+    ),
+  }))
+);
+
+const ProposalList = () => {
+  const [params] = useSearchParams();
+  const page = params.get('page') ?? '1';
+  const count = params.get('count') ?? '1000';
+  const fields = useCanonicalFields();
+  const proposals = useProposals(page, count);
+
+  useEffect(() => {
+    document.title = 'Proposal List - Philanthropy Data Commons';
+  }, []);
+
+  if (fields === null || proposals.length === 0) {
+    return (
+      <OidcSecure>
+        <div>Loading data...</div>
+      </OidcSecure>
+    );
+  }
+
+  return (
+    <OidcSecure>
+      <ProposalListTablePanel
+        fieldNames={mapFieldNames(fields)}
+        proposals={mapProposals(fields, proposals)}
+      />
+    </OidcSecure>
+  );
+};
+
+export { ProposalList };

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -6,6 +6,17 @@ const logger = getLogger('pdc-api');
 
 const API_URL = process.env.REACT_APP_API_URL;
 
+const throwNotOk = (res: Response): Response => {
+  if (!res.ok) {
+    throw new Error(`Response status: ${res.status} ${res.statusText}`);
+  }
+  return res;
+};
+
+const logError = (error: unknown, path: string) => {
+  logger.error({ error }, `Error fetching ${path}`);
+};
+
 // Custom React hook to make authenticated requests to the configured API
 const usePdcApi = <T>(path: string): T | null => {
   const { fetch } = useOidcFetch();
@@ -13,15 +24,10 @@ const usePdcApi = <T>(path: string): T | null => {
 
   useEffect(() => {
     fetch(new URL(path, API_URL))
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`Response status: ${res.status} ${res.statusText}`);
-        }
-        return res;
-      })
+      .then(throwNotOk)
       .then((res) => res.json())
       .then(setResponse)
-      .catch((error: unknown) => logger.error({ error }, `Error fetching ${path}`));
+      .catch((e) => logError(e, path));
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps --
      * fetch should not be a dependency, because although it or its internal

--- a/src/stories/ProposalListTable.stories.tsx
+++ b/src/stories/ProposalListTable.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ProposalListTable } from '../components/ProposalListTable';
+
+const meta = {
+  component: ProposalListTable,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        width: '100%',
+        maxHeight: '400px',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProposalListTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fieldNames: {
+      organization_name: 'Organization Name',
+      organization_tax_id: 'Organization Tax ID',
+      organization_city: 'Organization City',
+      organization_state_province: 'Organization State/Province',
+      organization_country: 'Organization Country',
+      organization_website: 'Organization Website',
+      organization_mission_statement: 'Organization Mission Statement',
+      organization_start_date: 'Organization Start Date',
+      organization_operating_budget: 'Organization Operating Budget',
+      proposal_title: 'Proposal Title',
+      proposal_summary: 'Proposal Summary',
+      proposal_amount_requested: 'Proposal Amount Requested',
+      proposal_budget: 'Proposal Budget',
+      proposal_fiscal_sponsor_name: 'Proposal Fiscal Sponsor Name',
+      proposal_start_date: 'Proposal Start Date',
+      proposal_end_date: 'Proposal End Date',
+      proposal_location_of_work: 'Proposal Location of Work',
+    },
+    proposals: [
+      {
+        id: '1',
+        values: {
+          organization_tax_id: ['12-3456789'],
+          organization_name: ['Acme Corp'],
+          organization_city: ['Los Angeles'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To create innovative solutions that make the world a better place.'],
+          organization_start_date: ['2005-03-15'],
+          organization_operating_budget: ['$5,000,000'],
+          proposal_title: ['Make Things Better'],
+          proposal_summary: ['Our proposal aims to improve access to clean water in underprivileged communities through the development of a low-cost water filtration system.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$50,000'],
+          proposal_fiscal_sponsor_name: ['The Charity Foundation'],
+          proposal_start_date: ['2022-06-01'],
+          proposal_end_date: ['2023-05-31'],
+          proposal_location_of_work: ['Rural areas in California, Nevada, and Arizona'],
+        },
+      },
+      {
+        id: '2',
+        values: {
+          organization_tax_id: ['98-7654321'],
+          organization_name: ['XYZ Inc.'],
+          organization_city: ['New York City'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To build a better world through technology.'],
+          organization_start_date: ['2010-01-01'],
+          organization_operating_budget: ['$10,000,000'],
+          proposal_title: ['Improve The World'],
+          proposal_summary: ['Our proposal aims to develop a new voting technology that will increase voter participation and improve election security.'],
+          proposal_amount_requested: ['$100,000'],
+          proposal_budget: ['$200,000'],
+          proposal_fiscal_sponsor_name: ['The Advocacy Fund'],
+          proposal_start_date: ['2023-01-01'],
+          proposal_end_date: ['2023-12-31'],
+          proposal_location_of_work: ['Nationwide'],
+        },
+      },
+      {
+        id: '3',
+        values: {
+          organization_tax_id: ['23-4567890'],
+          organization_name: ['Helping Hands'],
+          organization_city: ['New York'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To alleviate poverty and provide assistance to those in need.'],
+          organization_start_date: ['2000-05-01'],
+          organization_operating_budget: ['$15,000,000'],
+          proposal_title: ['Food for All'],
+          proposal_summary: ['Our proposal aims to establish a community kitchen to provide free meals to homeless individuals in the city.'],
+          proposal_amount_requested: ['$75,000'],
+          proposal_budget: ['$100,000'],
+          proposal_fiscal_sponsor_name: ['The Hunger Relief Fund'],
+          proposal_start_date: ['2023-10-01'],
+          proposal_end_date: ['2024-09-30'],
+          proposal_location_of_work: ['New York City'],
+        },
+      },
+
+      {
+        id: '4',
+        values: {
+          organization_tax_id: ['34-5678901'],
+          organization_name: ['Creative Minds'],
+          organization_city: ['San Francisco'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To promote creativity and innovation through education and the arts.'],
+          organization_start_date: ['2015-02-01'],
+          organization_operating_budget: ['$2,000,000'],
+          proposal_title: ['Art for All'],
+          proposal_summary: ['Our proposal aims to provide art classes and workshops to underserved communities in the city.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$75,000'],
+          proposal_fiscal_sponsor_name: ['The Art Education Foundation'],
+          proposal_start_date: ['2023-09-01'],
+          proposal_end_date: ['2024-08-31'],
+          proposal_location_of_work: ['San Francisco'],
+        },
+      },
+    ],
+    columns: [
+      'organization_name',
+      'organization_tax_id',
+      'organization_city',
+      'organization_state_province',
+      'organization_country',
+      'organization_website',
+      'organization_start_date',
+      'organization_operating_budget',
+      'proposal_title',
+      'proposal_summary',
+      'proposal_amount_requested',
+      'proposal_budget',
+      'proposal_fiscal_sponsor_name',
+      'proposal_start_date',
+      'proposal_end_date',
+      'proposal_location_of_work',
+    ],
+  },
+};

--- a/src/stories/ProposalListTablePanel.stories.tsx
+++ b/src/stories/ProposalListTablePanel.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
+
+const meta = {
+  component: ProposalListTablePanel,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        width: '100%',
+        height: '400px',
+        position: 'relative',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProposalListTablePanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fieldNames: {
+      organization_name: 'Organization Name',
+      organization_tax_id: 'Organization Tax ID',
+      organization_city: 'Organization City',
+      organization_state_province: 'Organization State/Province',
+      organization_country: 'Organization Country',
+      organization_website: 'Organization Website',
+      organization_mission_statement: 'Organization Mission Statement',
+      organization_start_date: 'Organization Start Date',
+      organization_operating_budget: 'Organization Operating Budget',
+      proposal_title: 'Proposal Title',
+      proposal_summary: 'Proposal Summary',
+      proposal_amount_requested: 'Proposal Amount Requested',
+      proposal_budget: 'Proposal Budget',
+      proposal_fiscal_sponsor_name: 'Proposal Fiscal Sponsor Name',
+      proposal_start_date: 'Proposal Start Date',
+      proposal_end_date: 'Proposal End Date',
+      proposal_location_of_work: 'Proposal Location of Work',
+    },
+    proposals: [
+      {
+        id: '1',
+        values: {
+          organization_tax_id: ['12-3456789'],
+          organization_name: ['Acme Corp'],
+          organization_city: ['Los Angeles'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To create innovative solutions that make the world a better place.'],
+          organization_start_date: ['2005-03-15'],
+          organization_operating_budget: ['$5,000,000'],
+          proposal_title: ['Make Things Better'],
+          proposal_summary: ['Our proposal aims to improve access to clean water in underprivileged communities through the development of a low-cost water filtration system.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$50,000'],
+          proposal_fiscal_sponsor_name: ['The Charity Foundation'],
+          proposal_start_date: ['2022-06-01'],
+          proposal_end_date: ['2023-05-31'],
+          proposal_location_of_work: ['Rural areas in California, Nevada, and Arizona'],
+        },
+      },
+      {
+        id: '2',
+        values: {
+          organization_tax_id: ['98-7654321'],
+          organization_name: ['XYZ Inc.'],
+          organization_city: ['New York City'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To build a better world through technology.'],
+          organization_start_date: ['2010-01-01'],
+          organization_operating_budget: ['$10,000,000'],
+          proposal_title: ['Improve The World'],
+          proposal_summary: ['Our proposal aims to develop a new voting technology that will increase voter participation and improve election security.'],
+          proposal_amount_requested: ['$100,000'],
+          proposal_budget: ['$200,000'],
+          proposal_fiscal_sponsor_name: ['The Advocacy Fund'],
+          proposal_start_date: ['2023-01-01'],
+          proposal_end_date: ['2023-12-31'],
+          proposal_location_of_work: ['Nationwide'],
+        },
+      },
+      {
+        id: '3',
+        values: {
+          organization_tax_id: ['23-4567890'],
+          organization_name: ['Helping Hands'],
+          organization_city: ['New York'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To alleviate poverty and provide assistance to those in need.'],
+          organization_start_date: ['2000-05-01'],
+          organization_operating_budget: ['$15,000,000'],
+          proposal_title: ['Food for All'],
+          proposal_summary: ['Our proposal aims to establish a community kitchen to provide free meals to homeless individuals in the city.'],
+          proposal_amount_requested: ['$75,000'],
+          proposal_budget: ['$100,000'],
+          proposal_fiscal_sponsor_name: ['The Hunger Relief Fund'],
+          proposal_start_date: ['2023-10-01'],
+          proposal_end_date: ['2024-09-30'],
+          proposal_location_of_work: ['New York City'],
+        },
+      },
+
+      {
+        id: '4',
+        values: {
+          organization_tax_id: ['34-5678901'],
+          organization_name: ['Creative Minds'],
+          organization_city: ['San Francisco'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To promote creativity and innovation through education and the arts.'],
+          organization_start_date: ['2015-02-01'],
+          organization_operating_budget: ['$2,000,000'],
+          proposal_title: ['Art for All'],
+          proposal_summary: ['Our proposal aims to provide art classes and workshops to underserved communities in the city.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$75,000'],
+          proposal_fiscal_sponsor_name: ['The Art Education Foundation'],
+          proposal_start_date: ['2023-09-01'],
+          proposal_end_date: ['2024-08-31'],
+          proposal_location_of_work: ['San Francisco'],
+        },
+      },
+    ],
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,24 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es5"
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,11 @@
     "moduleResolution": "node",
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "strictNullChecks": true,
     "target": "es5"
   },
   "include": [


### PR DESCRIPTION
This PR uses some of changes in #46 to add a list page at `/proposals?page=1&count=20` that will retrieve the list of proposals from the API, transform the data, and display it. Clicking on a row will navigate to the proposal detail page.
    
Currently, the API does not provide the necessary details in the proposal list response, so we have to do an N+1 query where we get the details for each proposal in the list. This can take a long time and be a lot of traffic, but until the API offers more information, it's the only thing to do.
    
This has some pagination support, via the `page` and `count` query parameters, like `/proposals?count=25&page=3`. These parameters are passed along to the API. However, because the API also does not return any information about how many proposals or how many pages there are, we cannot use the `<Paginator>` component created in #46, so instead just set the default `count` parameter to be very high. Again, until the API offers more information, the other alternatives lead to a bad user experience.

For now, we are hardcoding a list of field shortnames to show as columns, but the inner `<ProposalListTable>` does not know or care, so we should be well positioned to allow user customization eventually.

The table has a toggle for whether the contents should be displayed wrapped or truncated, and defaults to showing truncated data.

The table also has a non-functional search box to demonstrate eventual intended functionality.

Resolves #14