### PR TITLE
Show previous/next proposal buttons in dev mode

### DIFF
--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { DocumentTextIcon } from '@heroicons/react/24/solid';
+import { Link } from 'react-router-dom';
+import { BackwardIcon, DocumentTextIcon, ForwardIcon } from '@heroicons/react/24/solid';
 import {
   Panel,
+  PanelActions,
   PanelBody,
   PanelHeader,
   PanelTag,
@@ -15,6 +17,7 @@ interface ProposalDetailPanelProps {
   title: string | undefined;
   applicant: string;
   applicantId: string | undefined;
+  proposalId: number;
   version: number;
   values: {
     fieldName: string,
@@ -24,6 +27,7 @@ interface ProposalDetailPanelProps {
 }
 
 const ProposalDetailPanel = ({
+  proposalId,
   title,
   applicant,
   applicantId,
@@ -49,6 +53,20 @@ const ProposalDetailPanel = ({
           )}
         </PanelTitleTags>
       </PanelTitleWrapper>
+      <PanelActions>
+        {process.env.NODE_ENV !== 'production' && (
+          <Link to={`/proposal/${proposalId - 1}`}>
+            <BackwardIcon className="icon" />
+            Previous
+          </Link>
+        )}
+        {process.env.NODE_ENV !== 'production' && (
+          <Link to={`/proposal/${proposalId + 1}`}>
+            <ForwardIcon className="icon" />
+            Next
+          </Link>
+        )}
+      </PanelActions>
     </PanelHeader>
     <PanelBody>
       <ProposalTable

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -71,6 +71,7 @@ const ProposalDetail = () => {
     return (
       <OidcSecure>
         <ProposalDetailPanel
+          proposalId={0}
           title="Loading..."
           applicant="Loading..."
           applicantId="00-0000000"
@@ -91,6 +92,7 @@ const ProposalDetail = () => {
   return (
     <OidcSecure>
       <ProposalDetailPanel
+        proposalId={proposal.id}
         title={title}
         applicant={applicant}
         applicantId={applicantId}

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -42,6 +42,7 @@ interface CanonicalField {
 const useCanonicalFields = () => usePdcApi<CanonicalField[]>('/canonicalFields');
 
 interface Proposal {
+  id: number;
   versions: {
     version: number;
     fieldValues: {

--- a/src/stories/ProposalDetail.stories.tsx
+++ b/src/stories/ProposalDetail.stories.tsx
@@ -13,6 +13,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    proposalId: 1,
     title: 'Proposal Title',
     applicant: 'Organization Name',
     applicantId: '12-3456789',


### PR DESCRIPTION
Navigating by proposal ID is not an interface we want to show to users: there is no semantic meaning to the proposal ID, and it depends on the unsafe and incorrect assumption that there are no gaps in the sequence. Long-term, we plan to build a narrow list on the left side of the detail page that will allow navigating from one proposal to another.

However, developers do not really care about the lack of semantic meaning around proposal IDs; our concerns are more around how the data is displayed than what the data means. For that, quickly navigating through multiple proposals - in any arbitrary but consistent order - is very convenient.

Add previous/next links to the proposal detail page when run in dev mode (`npm run start`). Do not show these links when run in production mode (`npm run build`).

![Screen Shot 2023-04-06 at 02 07 55](https://user-images.githubusercontent.com/1494855/230330297-91b2bf6c-2c55-40f9-82d4-8775eb10b21b.png)

@reefdog I don't know why one icon is much bigger than the other; if this is revealing an underlying bug/assumption about how `<PanelActions>` are composed, or if it bothers you very much, please feel free to fix it!