### PR TITLE
Improve navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,8 @@
 }
 
 .App-navbar__item {
+  all: unset;
+
   display: flex;
   align-items: flex-start;
   gap: calc(var(--fixed-spacing--1x) / 2);
@@ -42,6 +44,10 @@
   text-decoration: none;
   padding: var(--fixed-spacing--1x);
   border-radius: 5px;
+}
+
+a.App-navbar__item,
+button.App-navbar__item {
   cursor: pointer;
 }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { HomeIcon } from '@heroicons/react/24/solid';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
 import { User } from './User';
 
 const Navbar = () => (
@@ -11,6 +12,15 @@ const Navbar = () => (
           <HomeIcon />
           Home
         </NavLink>
+      </li>
+      <li>
+        <a
+          href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons%20pilot%20data%20viewer"
+          className="App-navbar__item"
+        >
+          <EnvelopeIcon />
+          Feedback
+        </a>
       </li>
       <li>
         <User />

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useOidc, useOidcUser, OidcUserStatus } from '@axa-fr/react-oidc';
 import { UserIcon } from '@heroicons/react/24/solid';
-import { Button } from './Button';
 import { getLogger } from '../logger';
 
 const logger = getLogger('<User>');
@@ -13,34 +12,35 @@ const User = () => {
   switch (oidcUserLoadingState) {
     case OidcUserStatus.Loading:
       return (
-        <Button bordered disabled>
+        <div className="App-navbar__item App-navbar__item--loading">
           <UserIcon />
           Loading…
-        </Button>
+        </div>
       );
     case OidcUserStatus.Unauthenticated:
       return (
-        <Button
-          bordered
+        <button
+          className="App-navbar__item"
           onClick={() => { login('/').catch(logger.error); }}
+          type="button"
         >
           <UserIcon />
           Log in
-        </Button>
+        </button>
       );
     case OidcUserStatus.LoadingError:
       return (
-        <Button bordered color="red">
+        <div className="App-navbar__item App-navbar__item--error">
           <UserIcon />
           User loading failed
-        </Button>
+        </div>
       );
     default:
       return (
-        <Button bordered>
+        <div className="App-navbar__item">
           <UserIcon />
           {oidcUser.name}
-        </Button>
+        </div>
       );
   }
 };


### PR DESCRIPTION
This small PR offers two navbar improvements:

- Style the navbar login/user element like the others
   - Arguably, this _shouldn't_ look like the others since it's not clickable. I agree, but it will (soon, hopefully) work as a link to basic user functionality like going to the settings and logging out (probably through a menu). I'm okay with this temporary weirdness. It doesn't have a `cursor:pointer` at least.
- Add a "feedback" item to the navbar for pilot participants to email the team

In the current state:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/4731/230529655-4b4a4cfe-ab3e-4b7a-a684-35df2aea1f72.png">

This PR will have conflicts with the #49 currently in flight, but it'll be simple to resolve.

Closes #61 
Closes #65 