### PR TITLE
Change proposal detail URL to `/proposals/{id}`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <main className="App-main">
       <Routes>
         <Route path="/" element={<Placeholder />} />
-        <Route path="/proposal/:proposalId" element={<ProposalDetail />} />
+        <Route path="/proposals/:proposalId" element={<ProposalDetail />} />
         <Route path="/proposals" element={<ProposalList />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -58,14 +58,14 @@ const ProposalDetailPanel = ({
         {process.env.NODE_ENV !== 'production' && (
           <>
             <Link
-              to={`/proposal/${proposalId - 1}`}
+              to={`/proposals/${proposalId - 1}`}
               className="button button--color-gray"
             >
               <BackwardIcon className="icon" />
               Previous
             </Link>
             <Link
-              to={`/proposal/${proposalId + 1}`}
+              to={`/proposals/${proposalId + 1}`}
               className="button button--color-gray"
             >
               Next

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -24,7 +24,7 @@ const ProposalListTableRow = ({
   const navigate = useNavigate();
 
   const handleRowClick = () => {
-    navigate(`/proposal/${proposal.id}`);
+    navigate(`/proposals/${proposal.id}`);
   };
 
   return (


### PR DESCRIPTION
This PR implements the change from `/proposal/{id}` to `/proposals/{id}` for the proposal detail page. More justification in the issue and commit message.

To test, just make sure you can still navigate to the proposal detail page, and that the proposal list page still works (including with magic `count` changing).

Closes #63 