### PR TITLE
Improve minor landing page issues

### DIFF
--- a/src/components/OffsiteLink.tsx
+++ b/src/components/OffsiteLink.tsx
@@ -20,12 +20,12 @@ interface OffsiteLinkProps {
 
 /**
  * Component for linking off-site.
- * Defaults to opening links in a new window/tab (which can be disabled) and
- * automatically adds the `rel="noopener noreferrer"` attribute for cross-site safety.
+ * When configured to open links in a new window/tab, adds the
+ * `rel="noopener noreferrer"` attribute for cross-site safety.
  */
 export const OffsiteLink = ({
   to,
-  targetBlank = true,
+  targetBlank = false,
   children = undefined,
   className = undefined,
 }: OffsiteLinkProps) => (

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 :root {
   --color--gray--darker: #343434;
   --color--gray--dark: #444;
-  --color--gray--medium-dark: #999;
+  --color--gray--medium-dark: #757575;
   --color--gray--medium: #BBB;
   --color--gray--light: #EFEFEF;
   --color--gray--lighter: #FAFAFA;


### PR DESCRIPTION
@jasonaowen came in with some excellent thoughts in his [review](https://github.com/PhilanthropyDataCommons/data-viewer/pull/69#pullrequestreview-1376548149) of the PR #69 after it had already been merged, but they are worth resolving. So this PR:

- Improves the legibility of the medium-dark gray we're using for our `.subtle` text (e.g., "Contribute on GitHub" graf)
- Invert the default for offsite links so they _don't_ open in a new window/tab by default.