### PR TITLE
Go to proposals page from log in button

### DIFF
--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -21,7 +21,7 @@ const User = () => {
       return (
         <button
           className="App-navbar__item"
-          onClick={() => { login('/').catch(logger.error); }}
+          onClick={() => { login('/proposals').catch(logger.error); }}
           type="button"
         >
           <UserIcon />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -41,7 +41,7 @@ const Landing = () => {
           <Button
             color="blue"
             inverted
-            onClick={() => { login('/').catch(logger.error); }}
+            onClick={() => { login('/proposals').catch(logger.error); }}
           >
             <UserIcon className="icon" />
             Log in


### PR DESCRIPTION
Change the target of the two login buttons - in the `<User>` component of the navbar, and in the landing page - to go to `/proposals` instead of back to the landing page.

This does not affect the existing behavior of navigating to a secured page while signed out, which will continue to go through the login process and then redirect to the destination secured page.

Resolves #75 Go to Dashboard after initial login