### PR TITLE
Handle API change to use bundles

### DIFF
--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -75,6 +75,7 @@ const useProposals = (page: string, count: string) => {
     fetch(new URL(path, API_URL))
       .then(throwNotOk)
       .then((res) => res.json())
+      .then(({ entries }: { entries: Proposal[]; }) => entries)
       .then((data: { id: number; }[]) => data.map(({ id }) => id))
       .then(setProposals)
       .catch((e: unknown) => logError(e, path));


### PR DESCRIPTION
In PR [service#296](https://github.com/PhilanthropyDataCommons/service/pull/296), the return format of the `/proposals` API endpoint is changing from a top-level array of proposals to an object containing proposals under the `entries` key. It also returns the `total` number of proposals, which will allow us to do pagination, but that's separate work; for now, just update the parsing code to use the new format.