### PR TITLE
Rewrite panel layout to support sidebar and multiple panels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,19 +1,20 @@
 .App {
-  display: grid;
-  grid-template-rows: min-content 1fr;
-  gap: var(--fixed-spacing--1x);
-  padding: var(--fixed-spacing--1x);
-
   position: absolute;
   inset: 0;
+
+  padding: var(--fixed-spacing--1x);
+
+  display: grid;
+  grid: min-content 1fr / auto;
+  gap: var(--fixed-spacing--1x);
 }
 
 .App-header {
+  padding: var(--fixed-spacing--1x);
+
   display: flex;
   justify-content: space-between;
   align-items: center;
-
-  padding: var(--fixed-spacing--1x);
 }
 
 .App-logo {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { Header } from './components/Header';
+import { AppHeader } from './components/AppHeader';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
 import { ProposalList } from './pages/ProposalList';
@@ -9,7 +9,6 @@ import './App.css';
 
 const App = () => (
   <div className="App">
-    <Header />
     <main className="App-main">
       <Routes>
         <Route path="/" element={<Landing />} />
@@ -18,6 +17,7 @@ const App = () => (
         <Route path="*" element={<NotFound />} />
       </Routes>
     </main>
+    <AppHeader />
   </div>
 );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { AppHeader } from './components/AppHeader';
+import { AppMain } from './components/AppMain';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
 import { ProposalList } from './pages/ProposalList';
@@ -9,15 +10,15 @@ import './App.css';
 
 const App = () => (
   <div className="App">
-    <main className="App-main">
+    <AppHeader />
+    <AppMain>
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/proposals/:proposalId" element={<ProposalDetail />} />
         <Route path="/proposals" element={<ProposalList />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
-    </main>
-    <AppHeader />
+    </AppMain>
   </div>
 );
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { AppNavbar } from './AppNavbar';
 import logo from '../images/pdc-logo.png';
 
-const Header = () => (
+const AppHeader = () => (
   <header className="App-header">
     <a href="/">
       <img src={logo} className="App-logo" alt="Philanthropy Data Commons logo" />
@@ -11,4 +11,4 @@ const Header = () => (
   </header>
 );
 
-export { Header };
+export { AppHeader };

--- a/src/components/AppMain.tsx
+++ b/src/components/AppMain.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface AppMainProps {
+  children: React.ReactNode;
+}
+
+const AppMain = ({ children }: AppMainProps) => (
+  <main className="App-main">
+    {children}
+  </main>
+);
+
+export { AppMain };

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -4,7 +4,7 @@ import { EnvelopeIcon } from '@heroicons/react/24/outline';
 import { TableCellsIcon } from '@heroicons/react/24/solid';
 import { User } from './User';
 
-const Navbar = () => (
+const AppNavbar = () => (
   <nav className="App-navbar">
     <ul>
       <li>
@@ -29,4 +29,4 @@ const Navbar = () => (
   </nav>
 );
 
-export { Navbar };
+export { AppNavbar };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navbar } from './Navbar';
+import { AppNavbar } from './AppNavbar';
 import logo from '../images/pdc-logo.png';
 
 const Header = () => (
@@ -7,7 +7,7 @@ const Header = () => (
     <a href="/">
       <img src={logo} className="App-logo" alt="Philanthropy Data Commons logo" />
     </a>
-    <Navbar />
+    <AppNavbar />
   </header>
 );
 

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -8,12 +8,6 @@
   position: relative;
 }
 
-.panel.fill {
-  position: absolute;
-  inset: 0;
-  height: 100%;
-}
-
 .panel-header {
   grid-row: 1;
   padding: var(--fixed-spacing--1x);

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -4,15 +4,13 @@ import './Panel.css';
 interface PanelProps {
   children: React.ReactNode;
   className?: string;
-  fill?: boolean;
 }
 
 export const Panel = ({
   children,
   className = '',
-  fill = true,
 }: PanelProps) => (
-  <div className={`panel ${fill ? 'fill' : ''} ${className}`.trim()}>
+  <div className={`panel ${className}`.trim()}>
     {children}
   </div>
 );

--- a/src/components/PanelGrid/PanelGrid.css
+++ b/src/components/PanelGrid/PanelGrid.css
@@ -1,0 +1,30 @@
+.panel-grid {
+  position: absolute;
+  inset: 0;
+
+  display: grid;
+  grid: auto / auto-flow 1fr;
+  gap: 10px;
+
+  transition: grid 100ms;
+}
+
+.panel-grid.sidebarred {
+  /* Expressed as a CSS variable for future-proofing.
+     E.g., we can have a "closed sidebar" just by setting this variable
+     narrower with `.panel-grid.sidebarred.closed` or something,
+     without repeating our entire grid definition. */
+  --sidebar--width: clamp(250px, 20%, 500px);
+
+  grid: auto / var(--sidebar--width) repeat(auto-fit, minmax(0, 1fr));
+}
+
+.panel-grid-item {
+  position: relative;
+}
+
+.panel-grid-item .panel {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+}

--- a/src/components/PanelGrid/PanelGrid.tsx
+++ b/src/components/PanelGrid/PanelGrid.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import './PanelGrid.css';
+
+interface PanelGridProps {
+  /**
+   * Should only be passed `PanelGridItem` components.
+   */
+  children: React.ReactNode;
+  /**
+   * Makes the first panel sized properly for a sidebar.
+   * Doesn't require any additional markup on the sidebar panel.
+   */
+  sidebarred?: boolean;
+  className?: string;
+}
+
+export const PanelGrid = ({
+  children,
+  className = '',
+  sidebarred = false,
+}: PanelGridProps) => (
+  <div className={`panel-grid ${sidebarred ? 'sidebarred' : ''} ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/src/components/PanelGrid/PanelGridItem.tsx
+++ b/src/components/PanelGrid/PanelGridItem.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface PanelGridItemProps {
+  /**
+   * Should only be passed `Panel` components.
+   */
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const PanelGridItem = ({
+  children,
+  className = '',
+}: PanelGridItemProps) => (
+  <div className={`panel-grid-item ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/src/components/PanelGrid/index.ts
+++ b/src/components/PanelGrid/index.ts
@@ -1,0 +1,7 @@
+import { PanelGrid } from './PanelGrid';
+import { PanelGridItem } from './PanelGridItem';
+
+export {
+  PanelGrid,
+  PanelGridItem,
+};

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -16,10 +16,7 @@ const Landing = () => {
   const { login, isAuthenticated } = useOidc();
 
   return (
-    <Panel
-      fill={false}
-      className="landing-panel"
-    >
+    <Panel className="landing-panel">
       <PanelBody>
         <h3 style={{ fontWeight: '600' }}>Welcome to the Philanthropy Data Commons pilot.</h3>
         <p>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -7,6 +7,7 @@ import {
   useCanonicalFields,
   useProposal,
 } from '../pdc-api';
+import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
 
 const getValueOfCanonicalField = (
@@ -74,14 +75,18 @@ const ProposalDetail = () => {
   if (canonicalFields === null || proposal === null) {
     return (
       <OidcSecure>
-        <ProposalDetailPanel
-          proposalId={0}
-          title="Loading..."
-          applicant="Loading..."
-          applicantId="00-0000000"
-          version={0}
-          values={[]}
-        />
+        <PanelGrid>
+          <PanelGridItem>
+            <ProposalDetailPanel
+              proposalId={0}
+              title="Loading..."
+              applicant="Loading..."
+              applicantId="00-0000000"
+              version={0}
+              values={[]}
+            />
+          </PanelGridItem>
+        </PanelGrid>
       </OidcSecure>
     );
   }
@@ -95,14 +100,18 @@ const ProposalDetail = () => {
 
   return (
     <OidcSecure>
-      <ProposalDetailPanel
-        proposalId={proposal.id}
-        title={title}
-        applicant={applicant}
-        applicantId={applicantId}
-        version={version}
-        values={values}
-      />
+      <PanelGrid>
+        <PanelGridItem>
+          <ProposalDetailPanel
+            proposalId={proposal.id}
+            title={title}
+            applicant={applicant}
+            applicantId={applicantId}
+            version={version}
+            values={values}
+          />
+        </PanelGridItem>
+      </PanelGrid>
     </OidcSecure>
   );
 };

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -7,6 +7,7 @@ import {
   useCanonicalFields,
   useProposals,
 } from '../pdc-api';
+import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
 
 const mapFieldNames = (fields: CanonicalField[]) => Object.fromEntries(
@@ -59,10 +60,14 @@ const ProposalList = () => {
 
   return (
     <OidcSecure>
-      <ProposalListTablePanel
-        fieldNames={mapFieldNames(fields)}
-        proposals={mapProposals(fields, proposals)}
-      />
+      <PanelGrid>
+        <PanelGridItem>
+          <ProposalListTablePanel
+            fieldNames={mapFieldNames(fields)}
+            proposals={mapProposals(fields, proposals)}
+          />
+        </PanelGridItem>
+      </PanelGrid>
     </OidcSecure>
   );
 };

--- a/src/stories/PanelGrid.stories.tsx
+++ b/src/stories/PanelGrid.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
+import { Panel, PanelBody } from '../components/Panel';
+
+const meta = {
+  component: PanelGrid,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        position: 'relative',
+        width: '100%',
+        height: '400px',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PanelGrid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const panelGridItem = (
+  <PanelGridItem>
+    <Panel>
+      <PanelBody>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+      </PanelBody>
+    </Panel>
+  </PanelGridItem>
+);
+
+const sidebar = (
+  <PanelGridItem>
+    <Panel>
+      <PanelBody>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+        <p>Sidebar.</p>
+      </PanelBody>
+    </Panel>
+  </PanelGridItem>
+);
+
+export const Default: Story = {
+  args: {
+    children: [panelGridItem],
+  },
+};
+
+export const TwoPanels: Story = {
+  args: {
+    children: [panelGridItem, panelGridItem],
+  },
+};
+
+export const PlusSidebar: Story = {
+  args: {
+    children: [sidebar, panelGridItem],
+    sidebarred: true,
+  },
+};
+
+export const TwoPanelsPlusSidebar: Story = {
+  args: {
+    children: [sidebar, panelGridItem, panelGridItem],
+    sidebarred: true,
+  },
+};


### PR DESCRIPTION
This PR rewrites how we lay out the "full screen" style of panel so that we can support multiple adjacent panels with or without a sidebar panel.

Here is an example of what this would look like (though of course we would never show the same proposal twice like this):

<img width="1466" alt="Screenshot of the PDC proposal detail page with a sidebar and two panels" src="https://user-images.githubusercontent.com/4731/234151957-9a8c687a-04ae-41a6-8c92-78eafd41b7f3.png">

There are a few small prerequisite commits that clean up the root element formatting. See individual commits for the lily-pads.

**Testing:**

Nothing in the app should appear to have changed; the layout should work just as before:

1. `npm start`
2. Make sure the landing page looks the same
3. Log in
4. Make sure the proposal list looks the same
5. Make sure a proposal detail page looks the same
6. `npm run storybook`
7. Check out the new `PanelGrid` story, especially the variations

Contributes to #62 