### PR TITLE
Improve sticky table headers

### DIFF
--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -1,3 +1,7 @@
+:root {
+  --table--border-width: 1px;
+}
+
 .table {
   width: 100%;
 }
@@ -8,12 +12,12 @@
 
 .table thead.fixed {
   position: sticky;
-  top: 0;
+  top: calc(-1 * var(--table--border-width));
 }
 
 .table thead th {
-  border-top: 1px solid var(--color--gray--medium);
-  border-bottom: 1px solid var(--color--gray--medium);
+  border-top: var(--table--border-width) solid var(--color--gray--medium);
+  border-bottom: var(--table--border-width) solid var(--color--gray--medium);
   vertical-align: bottom;
   white-space: nowrap;
 }
@@ -26,8 +30,8 @@
 .table td {
   text-align: left;
   padding: var(--accessible-spacing--1x);
-  border-right: 1px solid var(--color--gray--light);
-  border-bottom: 1px solid var(--color--gray--light);
+  border-right: var(--table--border-width) solid var(--color--gray--light);
+  border-bottom: var(--table--border-width) solid var(--color--gray--light);
 }
 
 /* The last column should stretch to the table edge and have no right border. */
@@ -40,7 +44,7 @@
 /* The last body row should have a darker bottom border. */
 .table tbody tr:last-child th,
 .table tbody tr:last-child td {
-  border-bottom: 1px solid var(--color--gray--medium);
+  border-bottom: var(--table--border-width) solid var(--color--gray--medium);
 }
 
 .table tbody th,


### PR DESCRIPTION
Our table heads have top-borders. When the header is sticky, that top border used to remain visible when the header was sticky. That’s not ideal; a border is no longer needed to distinguish it from other content.

Before; watch the top of the panel as the header becomes sticky, how it looks like the shadow gets darker:

https://user-images.githubusercontent.com/4731/235010060-0b1a1060-49de-4a8b-a757-6c28d01a537a.mov

This PR makes the border defined via a CSS variable rather than statically, and sets the `top` property of the sticky header to the negative value of that variable so that the header scrolls that much out of view.

After; watch the top of the panel for how the shadow doesn't appear to get darker:

https://user-images.githubusercontent.com/4731/235010130-c40d2842-189e-4dff-8f85-c4d8dba27fd5.mov

