### PR TITLE
Fix proposal name field on table page

### DIFF
--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -29,7 +29,7 @@ const DEFAULT_COLUMNS = [
   'organization_mission_statement',
   'organization_start_date',
   'organization_operating_budget',
-  'proposal_title',
+  'proposal_name',
   'proposal_summary',
   'proposal_amount_requested',
   'proposal_budget',


### PR DESCRIPTION
The field that contains the proposal name is `proposal_name`, but the code is currently using `proposal_title` (which doesn't exist).

This PR updates the default column list on the proposal table page so the proposal name appears.

Testing:
1. Before pulling this code, look at the `/proposals` page and notice that there is an empty column between the "Organization Operating Budget" and "Proposal Summary" columns.
2. Pull the code and reload; now there should be a "Proposal Name" column (with data for some proposals).

Closes #89