### PR TITLE
Remove contribution prompt from login landing page

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -69,20 +69,6 @@ const Landing = () => {
               />
             </dd>
           </Dli>
-          <Dli className="subtle">
-            <dt>Contribute on GitHub:</dt>
-            <dd>
-              This project is developed as open source at
-              {' '}
-              <OffsiteLink to="https://github.com/PhilanthropyDataCommons">
-                PhilanthropyDataCommons
-              </OffsiteLink>
-              /
-              <OffsiteLink to="https://github.com/PhilanthropyDataCommons/data-viewer">
-                data-viewer
-              </OffsiteLink>
-            </dd>
-          </Dli>
         </dl>
       </PanelBody>
     </Panel>


### PR DESCRIPTION
It's better to keep the login landing page as simple and free of distractions as possible, since some newcomers might actually need to read it carefully to figure out what to do next.  We can put contribution information on other PDC pages, though: for example on informational pages about the PDC, and perhaps in the data viewer itself just elsewhere than the login landing page.

This resolves issue #88.