### PR TITLE
Use deep proposals data from API

### DIFF
--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -67,8 +67,7 @@ const useProposal = (proposalId: string) => (
 
 const useProposals = (page: string, count: string) => {
   const { fetch } = useOidcFetch();
-  const [proposals, setProposals] = useState<number[]>([]);
-  const [proposalsDetails, setProposalsDetails] = useState<Proposal[]>([]);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
 
   useEffect(() => {
     const path = `/proposals?_page=${page}&_count=${count}`;
@@ -76,24 +75,11 @@ const useProposals = (page: string, count: string) => {
       .then(throwNotOk)
       .then((res) => res.json())
       .then(({ entries }: { entries: Proposal[]; }) => entries)
-      .then((data: { id: number; }[]) => data.map(({ id }) => id))
       .then(setProposals)
       .catch((e: unknown) => logError(e, path));
   }, [page, count]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    Promise.all(
-      proposals.map((id) => (
-        fetch(new URL(`/proposals/${id}?includeFieldsAndValues=true`, API_URL))
-          .then(throwNotOk)
-          .then((res) => res.json())
-      )),
-    )
-      .then(setProposalsDetails)
-      .catch((error: unknown) => logger.error({ error }, 'Error fetching individual proposal in list'));
-  }, [proposals]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return proposalsDetails;
+  return proposals;
 };
 
 export {


### PR DESCRIPTION
Recently, [the API gained the ability to include all the necessary data in the `/proposals` endpoint](https://github.com/PhilanthropyDataCommons/service/pull/313), instead of only including IDs. As a result, we can stop making an additional N queries to `/proposal/{id}` to fill out the list, significantly improving load times.

We're still not using the [also-recently-introduced `total` field](https://github.com/PhilanthropyDataCommons/service/pull/296), which was introduced to support pagination, because instead we're doing [client-side search](https://github.com/PhilanthropyDataCommons/data-viewer/pull/84). Once [server-side search is ready](https://github.com/PhilanthropyDataCommons/service/pull/320), we'll be able to use that and implement pagination.