### PR TITLE
Add grid-based proposal list for sidebar

### DIFF
--- a/src/components/ProposalListGrid.tsx
+++ b/src/components/ProposalListGrid.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ProposalListGridItem } from './ProposalListGridItem';
+
+interface ProposalListGridProps {
+  proposals: {
+    id: string;
+    values: Record<string, string[]>;
+  }[];
+}
+
+export const ProposalListGrid = ({ proposals }: ProposalListGridProps) => (
+  <div className="proposal-list-grid">
+    {proposals.map((proposal, index) => (
+      <ProposalListGridItem
+        key={index} // eslint-disable-line react/no-array-index-key
+        proposal={proposal}
+      />
+    ))}
+  </div>
+);

--- a/src/components/ProposalListGridItem.css
+++ b/src/components/ProposalListGridItem.css
@@ -1,0 +1,28 @@
+.proposal-list-grid-item {
+  padding: var(--fixed-spacing--1x);
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--color--gray--light);
+  line-height: 1.1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--fixed-spacing--halfx);
+}
+
+.proposal-list-grid-item:hover {
+  background-color: var(--color--gray--lighter);
+}
+
+.proposal-list-grid-item:last-child {
+  border-bottom: none;
+}
+
+.proposal--organization-name {
+  font-weight: var(--font-weight--medium);
+}
+
+.proposal--organization-address,
+.proposal--proposal-name {
+  color: var(--color--gray--medium-dark);
+  font-size: 0.9em;
+}

--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './ProposalListGridItem.css';
+
+interface ProposalListGridItemProps {
+  proposal: {
+    id: string;
+    values: Record<string, string[]>;
+  };
+}
+
+export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) => {
+  const organizationName = proposal.values.organization_name
+    ?? proposal.values.organization_dba_name
+    ?? proposal.values.organization_legal_name
+    ?? proposal.values.proposal_primary_contact_name
+    ?? proposal.values.proposal_submitter_name
+    ?? 'Unknown Applicant';
+
+  const organizationLocation = ['organization_city', 'organization_state_province', 'organization_country']
+    .map((key) => proposal.values[key]?.filter((value) => value !== '')) // Filter out blank strings
+    .filter((value) => (value ?? []).length > 0) // Filter out empty value arrays
+    .join(', ');
+
+  return (
+    <Link
+      to={`/proposals/${proposal.id}`}
+      className="proposal-list-grid-item"
+    >
+      <div className="proposal--organization-name">
+        {organizationName}
+      </div>
+      {organizationLocation ? (
+        <div className="proposal--organization-address">
+          {organizationLocation}
+        </div>
+      ) : null}
+      {proposal.values.proposal_name ? (
+        <div className="proposal--proposal-name">
+          {proposal.values.proposal_name}
+        </div>
+      ) : null}
+    </Link>
+  );
+};

--- a/src/components/ProposalListGridPanel.tsx
+++ b/src/components/ProposalListGridPanel.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  Panel,
+  PanelBody,
+} from './Panel';
+import { ProposalListGrid } from './ProposalListGrid';
+
+interface ProposalListGridPanelProps {
+  proposals: {
+    id: string;
+    values: Record<string, string[]>;
+  }[];
+}
+
+export const ProposalListGridPanel = ({ proposals }: ProposalListGridPanelProps) => (
+  <Panel>
+    <PanelBody>
+      <ProposalListGrid proposals={proposals} />
+    </PanelBody>
+  </Panel>
+);

--- a/src/stories/ProposalListGridPanel.stories.tsx
+++ b/src/stories/ProposalListGridPanel.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
+
+const meta = {
+  component: ProposalListGridPanel,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{
+        width: '300px',
+        height: '500px',
+        position: 'relative',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProposalListGridPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    proposals: [
+      {
+        id: '1',
+        values: {
+          organization_tax_id: ['12-3456789'],
+          organization_name: ['Acme Corp'],
+          organization_city: ['Los Angeles'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To create innovative solutions that make the world a better place.'],
+          organization_start_date: ['2005-03-15'],
+          organization_operating_budget: ['$5,000,000'],
+          proposal_name: ['Make Things Better'],
+          proposal_summary: ['Our proposal aims to improve access to clean water in underprivileged communities through the development of a low-cost water filtration system.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$50,000'],
+          proposal_fiscal_sponsor_name: ['The Charity Foundation'],
+          proposal_start_date: ['2022-06-01'],
+          proposal_end_date: ['2023-05-31'],
+          proposal_location_of_work: ['Rural areas in California, Nevada, and Arizona'],
+        },
+      },
+      {
+        id: '2',
+        values: {
+          organization_tax_id: ['98-7654321'],
+          organization_name: ['XYZ Inc.'],
+          organization_city: ['New York City'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To build a better world through technology.'],
+          organization_start_date: ['2010-01-01'],
+          organization_operating_budget: ['$10,000,000'],
+          proposal_name: ['Improve The World'],
+          proposal_summary: ['Our proposal aims to develop a new voting technology that will increase voter participation and improve election security.'],
+          proposal_amount_requested: ['$100,000'],
+          proposal_budget: ['$200,000'],
+          proposal_fiscal_sponsor_name: ['The Advocacy Fund'],
+          proposal_start_date: ['2023-01-01'],
+          proposal_end_date: ['2023-12-31'],
+          proposal_location_of_work: ['Nationwide'],
+        },
+      },
+      {
+        id: '3',
+        values: {
+          organization_tax_id: ['23-4567890'],
+          organization_name: ['Helping Hands'],
+          organization_city: ['New York'],
+          organization_state_province: ['NY'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To alleviate poverty and provide assistance to those in need.'],
+          organization_start_date: ['2000-05-01'],
+          organization_operating_budget: ['$15,000,000'],
+          proposal_name: ['Food for All'],
+          proposal_summary: ['Our proposal aims to establish a community kitchen to provide free meals to homeless individuals in the city.'],
+          proposal_amount_requested: ['$75,000'],
+          proposal_budget: ['$100,000'],
+          proposal_fiscal_sponsor_name: ['The Hunger Relief Fund'],
+          proposal_start_date: ['2023-10-01'],
+          proposal_end_date: ['2024-09-30'],
+          proposal_location_of_work: ['New York City'],
+        },
+      },
+      {
+        id: '4',
+        values: {
+          organization_tax_id: ['34-5678901'],
+          organization_name: ['Creative Minds'],
+          organization_city: ['San Francisco'],
+          organization_state_province: ['CA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.org'],
+          organization_mission_statement: ['To promote creativity and innovation through education and the arts.'],
+          organization_start_date: ['2015-02-01'],
+          organization_operating_budget: ['$2,000,000'],
+          proposal_name: ['Art for All'],
+          proposal_summary: ['Our proposal aims to provide art classes and workshops to underserved communities in the city.'],
+          proposal_amount_requested: ['$50,000'],
+          proposal_budget: ['$75,000'],
+          proposal_fiscal_sponsor_name: ['The Art Education Foundation'],
+          proposal_start_date: ['2023-09-01'],
+          proposal_end_date: ['2024-08-31'],
+          proposal_location_of_work: ['San Francisco'],
+        },
+      },
+
+      {
+        id: '5',
+        values: {
+          organization_tax_id: ['45-6789012'],
+          organization_name: ['Green Earth'],
+          organization_city: ['Seattle'],
+          organization_state_province: ['WA'],
+          organization_country: ['USA'],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To promote sustainable living and protect the environment through education and advocacy.'],
+          organization_start_date: ['2008-01-01'],
+          organization_operating_budget: ['$5,000,000'],
+          proposal_name: [],
+          proposal_summary: ['Our proposal aims to collaborate with local government and businesses to make the city more environmentally friendly.'],
+          proposal_amount_requested: ['$100,000'],
+          proposal_budget: ['$150,000'],
+          proposal_fiscal_sponsor_name: ['The Environmental Alliance'],
+          proposal_start_date: ['2023-06-01'],
+          proposal_end_date: ['2024-05-31'],
+          proposal_location_of_work: ['Seattle'],
+        },
+      },
+
+      {
+        id: '6',
+        values: {
+          organization_tax_id: ['56-7890123'],
+          organization_name: ['Healthy Kids'],
+          organization_city: [''],
+          organization_state_province: [],
+          organization_country: [''],
+          organization_website: ['www.example.com'],
+          organization_mission_statement: ['To improve the health and wellbeing of children through education, advocacy, and access to healthcare.'],
+          organization_start_date: ['2010-10-01'],
+          organization_operating_budget: ['$3,000,000'],
+          proposal_name: ['Healthy School Meals'],
+          proposal_summary: ['Our proposal aims to provide healthy and nutritious meals to children in schools, while also promoting education about healthy eating habits.'],
+          proposal_amount_requested: ['$80,000'],
+          proposal_budget: ['$120,000'],
+          proposal_fiscal_sponsor_name: ['The Children\'s Health Foundation'],
+          proposal_start_date: ['2023-08-01'],
+          proposal_end_date: ['2024-07-31'],
+          proposal_location_of_work: ['Chicago'],
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This PR adds the components necessary for displaying a list of proposals in a grid-based format suitable for narrow contexts like a sidebar.

[Screenshot redacted because it contains identifiers of PDC pilot participant organizations.]

To add it to a page, you simply:

```diff
- <PanelGrid>
+ <PanelGrid sidebarred>
+   <PanelGridItem>
+     <ProposalListGridPanel
+       proposals={…}
+   />
+   </PanelGridItem>
    <PanelGridItem>
      {Other panel}
    </PanelGridItem>
  </PanelGrid>
```

Issue #62 