### PR TITLE
Conjoin search input and button

### DIFF
--- a/src/components/FormElementGroup.css
+++ b/src/components/FormElementGroup.css
@@ -1,0 +1,52 @@
+.form-element-group {
+  display: flex;
+  gap: 0;
+}
+
+.form-element-group > *:focus {
+  z-index: 1;
+}
+
+.form-element-group.horizontal {
+  flex-direction: row;
+}
+
+.form-element-group.horizontal > *:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.form-element-group.horizontal > *:not(:first-child, :last-child) {
+  border-radius: 0;
+}
+
+.form-element-group.horizontal > *:not(:first-child) {
+  border-left: 0;
+}
+
+.form-element-group.horizontal > *:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.form-element-group.vertical {
+  flex-direction: column;
+}
+
+.form-element-group.vertical > *:first-child {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.form-element-group.vertical > *:not(:first-child, :last-child) {
+  border-radius: 0;
+}
+
+.form-element-group.vertical > *:not(:first-child) {
+  border-top: 0;
+}
+
+.form-element-group.vertical > *:last-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/src/components/FormElementGroup.tsx
+++ b/src/components/FormElementGroup.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import './FormElementGroup.css';
+
+interface FormElementGroupProps {
+  children: React.ReactNode;
+  /**
+   * Do the elements stack beside each other or on top of each other?
+   */
+  direction?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+/**
+ * Component for making groups of form elements that appear side by side.
+ */
+export const FormElementGroup = ({
+  children,
+  direction = 'horizontal',
+  className = '',
+}: FormElementGroupProps) => (
+  <div className={`form-element-group ${direction} ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from './Button';
+import { FormElementGroup } from './FormElementGroup';
 import './Search.css';
 
 interface SearchProps {
@@ -20,19 +21,21 @@ export const Search = ({
       method="get"
       onSubmit={(e) => { e.preventDefault(); onSearch(query); }}
     >
-      <input
-        type="search"
-        name="q"
-        placeholder="Text to search for…"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-      <Button
-        submit
-        disabled={query === ''}
-      >
-        Search
-      </Button>
+      <FormElementGroup>
+        <input
+          type="search"
+          name="q"
+          placeholder="Text to search for…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <Button
+          submit
+          disabled={query === ''}
+        >
+          Search
+        </Button>
+      </FormElementGroup>
       {initialQuery !== '' ? (
         <Link
           to="/proposals"

--- a/src/stories/FormElementGroup.stories.tsx
+++ b/src/stories/FormElementGroup.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { FormElementGroup } from '../components/FormElementGroup';
+import { Button } from '../components/Button';
+
+const meta = {
+  component: FormElementGroup,
+  tags: ['autodocs'],
+} satisfies Meta<typeof FormElementGroup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: [
+      <Button>Button 1</Button>,
+      <Button>Button 2</Button>,
+    ],
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    direction: 'vertical',
+    children: [
+      <Button>Button 1</Button>,
+      <Button>Button 2</Button>,
+    ],
+  },
+};


### PR DESCRIPTION
This PR adds a `FormElementGroup` component that we can use to conjoin form elements (buttons, inputs) into horizontal or vertical groups. It also applies that component to the search atop the proposal list table, so the search input and its submit button are visually bound.

**Before:**
<img width="587" alt="1-before" src="https://user-images.githubusercontent.com/4731/235569460-fb8883e7-5069-419c-bed5-03cca4e51062.png">

**After:**
<img width="587" alt="2-after" src="https://user-images.githubusercontent.com/4731/235569470-87b29774-e94e-4b33-a985-9ff238eb2d69.png">

**Testing:**
- `npm start`
- Open the app in browser and confirm the search form looks like "After" above
- `npm run storybook`
- Open the Storybook in browser and look at the `FormElementGroup` docs and confirm they are 👍