### PR TITLE
Share the DataViewerProposal interface

### DIFF
--- a/src/components/ProposalListGrid.tsx
+++ b/src/components/ProposalListGrid.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { ProposalListGridItem } from './ProposalListGridItem';
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
 
 interface ProposalListGridProps {
-  proposals: {
-    id: string;
-    values: Record<string, string[]>;
-  }[];
+  proposals: DataViewerProposal[];
 }
 
 export const ProposalListGrid = ({ proposals }: ProposalListGridProps) => (

--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
 import './ProposalListGridItem.css';
 
 interface ProposalListGridItemProps {
-  proposal: {
-    id: string;
-    values: Record<string, string[]>;
-  };
+  proposal: DataViewerProposal;
 }
 
 export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) => {

--- a/src/components/ProposalListGridPanel.tsx
+++ b/src/components/ProposalListGridPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
 import {
   Panel,
   PanelBody,
@@ -6,10 +7,7 @@ import {
 import { ProposalListGrid } from './ProposalListGrid';
 
 interface ProposalListGridPanelProps {
-  proposals: {
-    id: string;
-    values: Record<string, string[]>;
-  }[];
+  proposals: DataViewerProposal[];
 }
 
 export const ProposalListGridPanel = ({ proposals }: ProposalListGridPanelProps) => (

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
 import {
   Table,
   TableHead,
@@ -11,10 +12,7 @@ import {
 
 interface ProposalListTableRowProps {
   columns: string[];
-  proposal: {
-    id: string;
-    values: Record<string, string[]>;
-  };
+  proposal: DataViewerProposal;
 }
 
 const ProposalListTableRow = ({
@@ -42,10 +40,7 @@ const ProposalListTableRow = ({
 interface ProposalListTableProps {
   columns: string[];
   fieldNames: Record<string, string>;
-  proposals: {
-    id: string;
-    values: Record<string, string[]>;
-  }[];
+  proposals: DataViewerProposal[];
   wrap?: boolean;
 }
 

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
 import {
   Panel,
   PanelHeader,
@@ -12,10 +13,7 @@ import { Search } from './Search';
 
 interface ProposalListTablePanelProps {
   fieldNames: Record<string, string>;
-  proposals: {
-    id: string;
-    values: Record<string, string[]>;
-  }[];
+  proposals: DataViewerProposal[];
   onSearch: (query: string) => void;
   searchQuery?: string;
 }

--- a/src/interfaces/DataViewerProposal.ts
+++ b/src/interfaces/DataViewerProposal.ts
@@ -1,0 +1,4 @@
+export interface DataViewerProposal {
+  id: string;
+  values: Record<string, string[]>;
+}


### PR DESCRIPTION
This PR creates a pattern for sharing TypeScript interfaces between files (`src/interfaces/Interface.ts`) and creates our first shared interface: `DataViewerProposal`. This is the interface that the DataViewer expects for a given proposal.

On its own, this PR changes nothing besides establishing the pattern with a single example. Future PRs will actually make more use of this shared interface.

**Testing:** Nothing should have broken or changed!