### PR TITLE
Get proposal values safely

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   getProposalValues,
+  getProposalValuesFromCandidates,
 } from './utils';
 
 test('can get proposal value', () => {
@@ -27,4 +28,38 @@ test('returns undefined for missing values', () => {
   expect(getProposalValues(proposal, 'empty_array')).toBeUndefined();
   expect(getProposalValues(proposal, 'string_only')).toBeUndefined();
   expect(getProposalValues(proposal, 'whitespace')).toBeUndefined();
+});
+
+test('can get best proposal value from candidates', () => {
+  const proposal = {
+    id: 'proposal',
+    values: {
+      empty_array: [],
+      string_only: [''],
+      org_legal_name: ['ABC Company, LLC'],
+      org_dba_name: ['XYZ Company'],
+    },
+  };
+
+  // Intentionally includes some attributes that should be skipped before the target attributes.
+  const preferDbaName = [
+    'missing_attribute',
+    'empty_array',
+    'string_only',
+    'org_dba_name',
+    'org_legal_name',
+  ];
+  const preferLegalName = [
+    'missing_attribute',
+    'empty_array',
+    'string_only',
+    'org_legal_name',
+    'org_dba_name',
+  ];
+
+  expect(getProposalValuesFromCandidates(proposal, preferDbaName))
+    .toEqual(proposal.values.org_dba_name);
+
+  expect(getProposalValuesFromCandidates(proposal, preferLegalName))
+    .toEqual(proposal.values.org_legal_name);
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,30 @@
+import {
+  getProposalValues,
+} from './utils';
+
+test('can get proposal value', () => {
+  const proposal = {
+    id: 'proposal',
+    values: {
+      org_name: ['ABC Company'],
+    },
+  };
+
+  expect(getProposalValues(proposal, 'org_name')).toEqual(proposal.values.org_name);
+});
+
+test('returns undefined for missing values', () => {
+  const proposal = {
+    id: 'proposal',
+    values: {
+      empty_array: [],
+      string_only: [''],
+      whitespace: [' '],
+    },
+  };
+
+  expect(getProposalValues(proposal, 'missing_attribute')).toBeUndefined();
+  expect(getProposalValues(proposal, 'empty_array')).toBeUndefined();
+  expect(getProposalValues(proposal, 'string_only')).toBeUndefined();
+  expect(getProposalValues(proposal, 'whitespace')).toBeUndefined();
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,25 @@
+import { DataViewerProposal } from './interfaces/DataViewerProposal';
+
+/**
+   * Safely gets the proposal value array for a given proposal attribute key.
+   *
+   * @param  {DataViewerProposal} proposal
+   * @param  {string} key The key for the proposal attribute we want.
+   * @return {(Array|undefined)} The proposal value array. Falls back to undefined.
+   */
+const getProposalValues = (proposal: DataViewerProposal, key: string) => {
+  // This is a temporary fix:
+  // The API currently allows fields to be set to blank strings,
+  // and dutifully includes those in the value array.
+  // We do not consider those valid when choosing a proposal value,
+  // so here we are making sure we have at least one non-blank/whitespace value.
+  if (!proposal.values[key]?.some((value) => value.trim() !== '')) {
+    return undefined;
+  }
+
+  return proposal.values[key];
+};
+
+export {
+  getProposalValues,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,22 @@ const getProposalValues = (proposal: DataViewerProposal, key: string) => {
   return proposal.values[key];
 };
 
+/**
+   * From a list of proposal attribute keys, safely gets the first valid proposal value array.
+   *
+   * Key order is relevant, as the first matching key's value will be returned.
+   *
+   * @param  {DataViewerProposal} proposal
+   * @param  {string[]} keys An array of keys, ordered by preference with most-preferred first.
+   * @return {(Array|undefined)} The proposal value array. Falls back to undefined.
+   */
+const getProposalValuesFromCandidates = (proposal: DataViewerProposal, keys: string[]) => {
+  const bestKey = keys.find((key) => (key in proposal.values && getProposalValues(proposal, key)));
+
+  return bestKey ? getProposalValues(proposal, bestKey) : undefined;
+};
+
 export {
   getProposalValues,
+  getProposalValuesFromCandidates,
 };


### PR DESCRIPTION
_This PR ladders off #99._

This PR adds two utility methods, as well as tests of those methods.

- `getProposalValue()` lets you safely fetch the value of a particular attribute, returning `undefined` if the value isn't valid (missing, empty array, or array of empty strings), or the value if it is.
- `getProposalValueFromCandidates()` accepts an array of keys and returns the first good one, or undefined if none are.

While this PR doesn't demonstrate their use, a future PR will use these to fix #100.

Note: Neither of these methods handles the concern of how we join arrays of values for display in the interface. That would be a different method, or possibly even a React component. Either way, we're punting on it for now because we don't have any data like that.

**Testing:**
- `npm run test` yay!