### PR TITLE
Safely select organization name in proposal list

### DIFF
--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { getProposalValuesFromCandidates } from '../utils';
 import './ProposalListGridItem.css';
 
 interface ProposalListGridItemProps {
@@ -8,12 +9,13 @@ interface ProposalListGridItemProps {
 }
 
 export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) => {
-  const organizationName = proposal.values.organization_name
-    ?? proposal.values.organization_dba_name
-    ?? proposal.values.organization_legal_name
-    ?? proposal.values.proposal_primary_contact_name
-    ?? proposal.values.proposal_submitter_name
-    ?? 'Unknown Applicant';
+  const organizationName = getProposalValuesFromCandidates(proposal, [
+    'organization_name',
+    'organization_dba_name',
+    'organization_legal_name',
+    'proposal_primary_contact_name',
+    'proposal_submitter_name',
+  ]) ?? 'Unknown Applicant';
 
   const organizationLocation = ['organization_city', 'organization_state_province', 'organization_country']
     .map((key) => proposal.values[key]?.filter((value) => value !== '')) // Filter out blank strings


### PR DESCRIPTION
_This PR ladders off #101, and that one needs merging before this one._

This PR uses `getProposalValueFromCandidates()` to correctly select the organization name for display in the proposal list sidebar, fixing the issue where we were displaying empty organization names for many orgs.

**Testing:**
1. On `main`, add the sidebar to `pages/ProposalList.tsx` (see description of #94 for code)
2. `npm start` and look at `/proposals`, scrolling the sidebar list
3. You should see lots of blank cells (may be below the fold)
4. Switch to this branch
5. Now those cells should be populated with an organization name

Closes #100