### PR TITLE
Refactor API client code

### DIFF
--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -58,7 +58,7 @@ const ProposalList = () => {
     document.title = 'Proposal List - Philanthropy Data Commons';
   }, []);
 
-  if (fields === null || proposals.length === 0) {
+  if (fields === null || proposals === null) {
     return (
       <OidcSecure>
         <div>Loading data...</div>
@@ -66,13 +66,18 @@ const ProposalList = () => {
     );
   }
 
+  const mappedProposals = mapProposals(
+    fields,
+    proposals.entries.filter((p) => fieldValueMatches(p, query)),
+  );
+
   return (
     <OidcSecure>
       <PanelGrid>
         <PanelGridItem>
           <ProposalListTablePanel
             fieldNames={mapFieldNames(fields)}
-            proposals={mapProposals(fields, proposals.filter((p) => fieldValueMatches(p, query)))}
+            proposals={mappedProposals}
             searchQuery={query}
             onSearch={(q) => navigate(`/proposals?q=${q}`)}
           />

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -97,7 +97,6 @@ const useProposals = (page: string, count: string) => (
 
 export {
   useCanonicalFields,
-  usePdcApi,
   useProposal,
   useProposals,
 };

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -65,16 +65,20 @@ const useProposal = (proposalId: string) => (
   usePdcApi<Proposal>(`/proposals/${proposalId}?includeFieldsAndValues=true`)
 );
 
+interface Proposals {
+  entries: Proposal[];
+  total: number;
+}
+
 const useProposals = (page: string, count: string) => {
   const { fetch } = useOidcFetch();
-  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [proposals, setProposals] = useState<Proposals | null>(null);
 
   useEffect(() => {
     const path = `/proposals?_page=${page}&_count=${count}`;
     fetch(new URL(path, API_URL))
       .then(throwNotOk)
       .then((res) => res.json())
-      .then(({ entries }: { entries: Proposal[]; }) => entries)
       .then(setProposals)
       .catch((e: unknown) => logError(e, path));
   }, [page, count]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -70,21 +70,9 @@ interface Proposals {
   total: number;
 }
 
-const useProposals = (page: string, count: string) => {
-  const { fetch } = useOidcFetch();
-  const [proposals, setProposals] = useState<Proposals | null>(null);
-
-  useEffect(() => {
-    const path = `/proposals?_page=${page}&_count=${count}`;
-    fetch(new URL(path, API_URL))
-      .then(throwNotOk)
-      .then((res) => res.json())
-      .then(setProposals)
-      .catch((e: unknown) => logError(e, path));
-  }, [page, count]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return proposals;
-};
+const useProposals = (page: string, count: string) => (
+  usePdcApi<Proposals>(`/proposals?_page=${page}&_count=${count}`)
+);
 
 export {
   useCanonicalFields,


### PR DESCRIPTION
As I was working on supporting server-side search, and implementing the proposal list sidebar on the proposal detail page, I found that the API client code wasn't quite well suited to the task. Partly, this is because of previous changes, and partly because we're introducing new requirements.

In order to reduce the scope of these changes, make them now, before we implement the sidebar.

This is purely a refactor, and should not change the behavior of the application. See the individual commit messages for more details.

Issue https://github.com/PhilanthropyDataCommons/data-viewer/issues/15 Implement pagination on proposal lists
Issue #62 Add sidebar to Proposal Detail page
Issue https://github.com/PhilanthropyDataCommons/data-viewer/issues/83 Enable search