### PR TITLE
Use 'Base Field' label in proposal detail page

### DIFF
--- a/src/components/ProposalTable.tsx
+++ b/src/components/ProposalTable.tsx
@@ -41,7 +41,7 @@ export const ProposalTable = ({
             actions
             actionAlignment="left"
           >
-            Canonical Field
+            Base Field
             <ColumnActions>
               <ColumnAction
                 title="Toggle between field label and short code"


### PR DESCRIPTION
The code still uses the "canonical" name internally, but fix it in the UI so that users will see the new term.

@reefdog, please merge this if it looks good - please don't wait for me if you want to include it in the demo!

Resolves #97 Rename "Canonical Field" to "Base Field"