### PR TITLE
 Add proposal list sidebar to proposal detail page 

### DIFF
--- a/src/map-proposals.ts
+++ b/src/map-proposals.ts
@@ -1,0 +1,28 @@
+import type { CanonicalField, Proposal } from './pdc-api';
+
+const extendMultimapReducer = (
+  multimap: Record<string, string[]>,
+  [key, value]: [string, string],
+): Record<string, string[]> => ({
+  [key]: (multimap[key] ?? []).concat([value]),
+  ...multimap,
+});
+
+const mapProposals = (fields: CanonicalField[], proposals: Proposal[]) => (
+  proposals.map((proposal: Proposal) => ({
+    id: proposal.id.toString(),
+    values: (
+      (proposal.versions[0]?.fieldValues ?? []).map(({
+        applicationFormField: { canonicalFieldId },
+        value,
+      }) => [
+        fields.find(({ id }) => (id === canonicalFieldId))?.shortCode,
+        value,
+      ])
+        .filter((pair): pair is [string, string] => !!pair[0])
+        .reduce(extendMultimapReducer, {})
+    ),
+  }))
+);
+
+export { mapProposals };

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { OidcSecure } from '@axa-fr/react-oidc';
+import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useParams } from 'react-router-dom';
 import {
   CanonicalField,
@@ -56,7 +56,7 @@ const getApplicant = (
     ?? 'Unknown Applicant'
 );
 
-const ProposalDetail = () => {
+const ProposalDetailLoader = () => {
   const params = useParams();
   const proposalId = params.proposalId ?? 'missing';
   const canonicalFields = useCanonicalFields();
@@ -74,20 +74,18 @@ const ProposalDetail = () => {
 
   if (canonicalFields === null || proposal === null) {
     return (
-      <OidcSecure>
-        <PanelGrid>
-          <PanelGridItem>
-            <ProposalDetailPanel
-              proposalId={0}
-              title="Loading..."
-              applicant="Loading..."
-              applicantId="00-0000000"
-              version={0}
-              values={[]}
-            />
-          </PanelGridItem>
-        </PanelGrid>
-      </OidcSecure>
+      <PanelGrid>
+        <PanelGridItem>
+          <ProposalDetailPanel
+            proposalId={0}
+            title="Loading..."
+            applicant="Loading..."
+            applicantId="00-0000000"
+            version={0}
+            values={[]}
+          />
+        </PanelGridItem>
+      </PanelGrid>
     );
   }
 
@@ -99,21 +97,20 @@ const ProposalDetail = () => {
   const values = mapCanonicalFields(canonicalFields, proposal);
 
   return (
-    <OidcSecure>
-      <PanelGrid>
-        <PanelGridItem>
-          <ProposalDetailPanel
-            proposalId={proposal.id}
-            title={title}
-            applicant={applicant}
-            applicantId={applicantId}
-            version={version}
-            values={values}
-          />
-        </PanelGridItem>
-      </PanelGrid>
-    </OidcSecure>
+    <PanelGrid>
+      <PanelGridItem>
+        <ProposalDetailPanel
+          proposalId={proposal.id}
+          title={title}
+          applicant={applicant}
+          applicantId={applicantId}
+          version={version}
+          values={values}
+        />
+      </PanelGridItem>
+    </PanelGrid>
   );
 };
 
+const ProposalDetail = withOidcSecure(ProposalDetailLoader);
 export { ProposalDetail };

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -6,9 +6,36 @@ import {
   Proposal,
   useCanonicalFields,
   useProposal,
+  useProposals,
 } from '../pdc-api';
+import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
+import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
+
+interface ProposalListGridLoaderProps {
+  canonicalFields: CanonicalField[] | null;
+}
+
+const ProposalListGridLoader = (
+  { canonicalFields }: ProposalListGridLoaderProps,
+) => {
+  const proposals = useProposals('1', '1000');
+
+  if (canonicalFields === null || proposals === null) {
+    return (
+      <div>Loading data...</div>
+    );
+  }
+
+  return (
+    <PanelGridItem>
+      <ProposalListGridPanel
+        proposals={mapProposals(canonicalFields, proposals.entries)}
+      />
+    </PanelGridItem>
+  );
+};
 
 const getValueOfCanonicalField = (
   canonicalFields: CanonicalField[],
@@ -56,10 +83,15 @@ const getApplicant = (
     ?? 'Unknown Applicant'
 );
 
-const ProposalDetailLoader = () => {
+interface ProposalDetailPanelLoaderProps {
+  canonicalFields: CanonicalField[] | null;
+}
+
+const ProposalDetailPanelLoader = (
+  { canonicalFields }: ProposalDetailPanelLoaderProps,
+) => {
   const params = useParams();
   const proposalId = params.proposalId ?? 'missing';
-  const canonicalFields = useCanonicalFields();
   const proposal = useProposal(proposalId);
 
   useEffect(() => {
@@ -74,18 +106,16 @@ const ProposalDetailLoader = () => {
 
   if (canonicalFields === null || proposal === null) {
     return (
-      <PanelGrid>
-        <PanelGridItem>
-          <ProposalDetailPanel
-            proposalId={0}
-            title="Loading..."
-            applicant="Loading..."
-            applicantId="00-0000000"
-            version={0}
-            values={[]}
-          />
-        </PanelGridItem>
-      </PanelGrid>
+      <PanelGridItem>
+        <ProposalDetailPanel
+          proposalId={0}
+          title="Loading..."
+          applicant="Loading..."
+          applicantId="00-0000000"
+          version={0}
+          values={[]}
+        />
+      </PanelGridItem>
     );
   }
 
@@ -97,17 +127,30 @@ const ProposalDetailLoader = () => {
   const values = mapCanonicalFields(canonicalFields, proposal);
 
   return (
-    <PanelGrid>
-      <PanelGridItem>
-        <ProposalDetailPanel
-          proposalId={proposal.id}
-          title={title}
-          applicant={applicant}
-          applicantId={applicantId}
-          version={version}
-          values={values}
-        />
-      </PanelGridItem>
+    <PanelGridItem>
+      <ProposalDetailPanel
+        proposalId={proposal.id}
+        title={title}
+        applicant={applicant}
+        applicantId={applicantId}
+        version={version}
+        values={values}
+      />
+    </PanelGridItem>
+  );
+};
+
+const ProposalDetailLoader = () => {
+  const canonicalFields = useCanonicalFields();
+
+  return (
+    <PanelGrid sidebarred>
+      <ProposalListGridLoader
+        canonicalFields={canonicalFields}
+      />
+      <ProposalDetailPanelLoader
+        canonicalFields={canonicalFields}
+      />
     </PanelGrid>
   );
 };

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -7,36 +7,12 @@ import {
   useCanonicalFields,
   useProposals,
 } from '../pdc-api';
+import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
 
 const mapFieldNames = (fields: CanonicalField[]) => Object.fromEntries(
   fields.map(({ label, shortCode }) => [shortCode, label]),
-);
-
-const extendMultimapReducer = (
-  multimap: Record<string, string[]>,
-  [key, value]: [string, string],
-): Record<string, string[]> => ({
-  [key]: (multimap[key] ?? []).concat([value]),
-  ...multimap,
-});
-
-const mapProposals = (fields: CanonicalField[], proposals: Proposal[]) => (
-  proposals.map((proposal: Proposal) => ({
-    id: proposal.id.toString(),
-    values: (
-      (proposal.versions[0]?.fieldValues ?? []).map(({
-        applicationFormField: { canonicalFieldId },
-        value,
-      }) => [
-        fields.find(({ id }) => (id === canonicalFieldId))?.shortCode,
-        value,
-      ])
-        .filter((pair): pair is [string, string] => !!pair[0])
-        .reduce(extendMultimapReducer, {})
-    ),
-  }))
 );
 
 const fieldValueMatches = (proposal: Proposal, query: string) => (

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { OidcSecure } from '@axa-fr/react-oidc';
+import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   CanonicalField,
@@ -45,7 +45,7 @@ const fieldValueMatches = (proposal: Proposal, query: string) => (
   )
 );
 
-const ProposalList = () => {
+const ProposalListLoader = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const page = params.get('page') ?? '1';
@@ -60,9 +60,7 @@ const ProposalList = () => {
 
   if (fields === null || proposals === null) {
     return (
-      <OidcSecure>
-        <div>Loading data...</div>
-      </OidcSecure>
+      <div>Loading data...</div>
     );
   }
 
@@ -72,19 +70,18 @@ const ProposalList = () => {
   );
 
   return (
-    <OidcSecure>
-      <PanelGrid>
-        <PanelGridItem>
-          <ProposalListTablePanel
-            fieldNames={mapFieldNames(fields)}
-            proposals={mappedProposals}
-            searchQuery={query}
-            onSearch={(q) => navigate(`/proposals?q=${q}`)}
-          />
-        </PanelGridItem>
-      </PanelGrid>
-    </OidcSecure>
+    <PanelGrid>
+      <PanelGridItem>
+        <ProposalListTablePanel
+          fieldNames={mapFieldNames(fields)}
+          proposals={mappedProposals}
+          searchQuery={query}
+          onSearch={(q) => navigate(`/proposals?q=${q}`)}
+        />
+      </PanelGridItem>
+    </PanelGrid>
   );
 };
 
+const ProposalList = withOidcSecure(ProposalListLoader);
 export { ProposalList };


### PR DESCRIPTION
Use the new `<ProposalListGridPanel>` component introduced in #94 in a sidebar on the proposal detail page.

See the individual commits for more details.

Resolves #62 Add sidebar to Proposal Detail page