### PR TITLE
Rename API interface type definitions

### DIFF
--- a/src/map-proposals.ts
+++ b/src/map-proposals.ts
@@ -1,4 +1,4 @@
-import type { CanonicalField, Proposal } from './pdc-api';
+import type { ApiCanonicalField, ApiProposal } from './pdc-api';
 
 const extendMultimapReducer = (
   multimap: Record<string, string[]>,
@@ -8,8 +8,8 @@ const extendMultimapReducer = (
   ...multimap,
 });
 
-const mapProposals = (fields: CanonicalField[], proposals: Proposal[]) => (
-  proposals.map((proposal: Proposal) => ({
+const mapProposals = (fields: ApiCanonicalField[], proposals: ApiProposal[]) => (
+  proposals.map((proposal) => ({
     id: proposal.id.toString(),
     values: (
       (proposal.versions[0]?.fieldValues ?? []).map(({

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useParams } from 'react-router-dom';
 import {
-  CanonicalField,
-  Proposal,
+  ApiCanonicalField,
+  ApiProposal,
   useCanonicalFields,
   useProposal,
   useProposals,
@@ -14,7 +14,7 @@ import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
 import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
 
 interface ProposalListGridLoaderProps {
-  canonicalFields: CanonicalField[] | null;
+  canonicalFields: ApiCanonicalField[] | null;
 }
 
 const ProposalListGridLoader = (
@@ -38,8 +38,8 @@ const ProposalListGridLoader = (
 };
 
 const getValueOfCanonicalField = (
-  canonicalFields: CanonicalField[],
-  proposal: Proposal,
+  canonicalFields: ApiCanonicalField[],
+  proposal: ApiProposal,
   canonicalFieldShortCode: string,
 ) => {
   const field = canonicalFields.find(({ shortCode }) => (
@@ -55,8 +55,8 @@ const getValueOfCanonicalField = (
 };
 
 const mapCanonicalFields = (
-  canonicalFields: CanonicalField[],
-  proposal: Proposal,
+  canonicalFields: ApiCanonicalField[],
+  proposal: ApiProposal,
 ) => (
   (proposal.versions[0]?.fieldValues ?? []).map(({ applicationFormField, value }) => {
     const canonicalField = canonicalFields.find(({ id }) => (
@@ -72,8 +72,8 @@ const mapCanonicalFields = (
 );
 
 const getApplicant = (
-  canonicalFields: CanonicalField[],
-  proposal: Proposal,
+  canonicalFields: ApiCanonicalField[],
+  proposal: ApiProposal,
 ) => (
   getValueOfCanonicalField(canonicalFields, proposal, 'organization_name')
     ?? getValueOfCanonicalField(canonicalFields, proposal, 'organization_dba_name')
@@ -84,7 +84,7 @@ const getApplicant = (
 );
 
 interface ProposalDetailPanelLoaderProps {
-  canonicalFields: CanonicalField[] | null;
+  canonicalFields: ApiCanonicalField[] | null;
 }
 
 const ProposalDetailPanelLoader = (

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
-  CanonicalField,
-  Proposal,
+  ApiCanonicalField,
+  ApiProposal,
   useCanonicalFields,
   useProposals,
 } from '../pdc-api';
@@ -11,11 +11,11 @@ import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
 
-const mapFieldNames = (fields: CanonicalField[]) => Object.fromEntries(
+const mapFieldNames = (fields: ApiCanonicalField[]) => Object.fromEntries(
   fields.map(({ label, shortCode }) => [shortCode, label]),
 );
 
-const fieldValueMatches = (proposal: Proposal, query: string) => (
+const fieldValueMatches = (proposal: ApiProposal, query: string) => (
   proposal.versions[0]?.fieldValues.some(
     ({ value }) => value.toLowerCase().includes(query.toLowerCase()),
   )

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -49,15 +49,15 @@ const usePdcApi = <T>(
   return response;
 };
 
-interface CanonicalField {
+interface ApiCanonicalField {
   id: number;
   label: string;
   shortCode: string;
 }
 
-const useCanonicalFields = () => usePdcApi<CanonicalField[]>('/canonicalFields');
+const useCanonicalFields = () => usePdcApi<ApiCanonicalField[]>('/canonicalFields');
 
-interface Proposal {
+interface ApiProposal {
   id: number;
   versions: {
     version: number;
@@ -72,7 +72,7 @@ interface Proposal {
 }
 
 const useProposal = (proposalId: string) => (
-  usePdcApi<Proposal>(
+  usePdcApi<ApiProposal>(
     `/proposals/${proposalId}`,
     new URLSearchParams({
       includeFieldsAndValues: 'true',
@@ -80,13 +80,13 @@ const useProposal = (proposalId: string) => (
   )
 );
 
-interface Proposals {
-  entries: Proposal[];
+interface ApiProposals {
+  entries: ApiProposal[];
   total: number;
 }
 
 const useProposals = (page: string, count: string) => (
-  usePdcApi<Proposals>(
+  usePdcApi<ApiProposals>(
     '/proposals',
     new URLSearchParams({
       _page: page,
@@ -102,6 +102,6 @@ export {
 };
 
 export type {
-  CanonicalField,
-  Proposal,
+  ApiCanonicalField,
+  ApiProposal,
 };


### PR DESCRIPTION
In PR #99, we introduced a name for the display-centric models we are using. The name introduced, `DataViewerProposal`, is prefixed to distinguish itself from the type definitions for how the API represents data.

Rename the API-centric interfaces to include an `Api` prefix.

These new names make it clearer that we should not be using these interfaces so widely, but cleaning that up will be part of future work.

Issue #108 Rename shared TypeScript interfaces for clarity