### PR TITLE
Use server search API

### DIFF
--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -69,6 +69,11 @@
   grid-row: 2;
 }
 
+.panel-message {
+  padding: var(--fixed-spacing--1x);
+  color: var(--color--gray--medium-dark);
+}
+
 .panel.fill .panel-body {
   position: absolute;
   inset: 0;

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -16,6 +16,7 @@ interface ProposalListTablePanelProps {
   proposals: DataViewerProposal[];
   onSearch: (query: string) => void;
   searchQuery?: string;
+  loading?: boolean;
 }
 
 // For now, we are hard-coding this list.
@@ -45,10 +46,13 @@ export const ProposalListTablePanel = ({
   proposals,
   onSearch,
   searchQuery = '',
+  loading = false,
 }: ProposalListTablePanelProps) => {
   const [wrap, setWrap] = useState(false);
 
   const handleWrapClick = () => setWrap((previous) => !previous);
+
+  const hasSearchQuery = searchQuery !== '';
 
   return (
     <Panel>
@@ -67,12 +71,18 @@ export const ProposalListTablePanel = ({
         </PanelActions>
       </PanelHeader>
       <PanelBody>
-        <ProposalListTable
-          fieldNames={fieldNames}
-          proposals={proposals}
-          columns={DEFAULT_COLUMNS}
-          wrap={wrap}
-        />
+        {loading ? (
+          <div className="panel-message">
+            {hasSearchQuery ? 'Searching…' : 'Loading…'}
+          </div>
+        ) : (
+          <ProposalListTable
+            fieldNames={fieldNames}
+            proposals={proposals}
+            columns={DEFAULT_COLUMNS}
+            wrap={wrap}
+          />
+        )}
       </PanelBody>
     </Panel>
   );

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -69,15 +69,17 @@ export const ProposalListTablePanel = ({
         <PanelActions>
           <Search onSearch={onSearch} initialQuery={searchQuery} />
         </PanelActions>
-        <PanelActions>
-          <Button
-            onClick={handleWrapClick}
-            color={wrap ? 'blue' : 'gray'}
-          >
-            <Bars3BottomLeftIcon className="icon" />
-            Toggle wrapping
-          </Button>
-        </PanelActions>
+        {hasProposals && (
+          <PanelActions>
+            <Button
+              onClick={handleWrapClick}
+              color={wrap ? 'blue' : 'gray'}
+            >
+              <Bars3BottomLeftIcon className="icon" />
+              Toggle wrapping
+            </Button>
+          </PanelActions>
+        )}
       </PanelHeader>
       <PanelBody>
         {hasProposals ? (

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -52,7 +52,16 @@ export const ProposalListTablePanel = ({
 
   const handleWrapClick = () => setWrap((previous) => !previous);
 
+  const hasProposals = proposals.length > 0;
   const hasSearchQuery = searchQuery !== '';
+
+  const generateFallbackMessage = () => {
+    if (hasSearchQuery) {
+      return loading ? 'Searching…' : 'No search results for that query.';
+    }
+
+    return loading ? 'Loading…' : 'No data available.';
+  };
 
   return (
     <Panel>
@@ -71,17 +80,17 @@ export const ProposalListTablePanel = ({
         </PanelActions>
       </PanelHeader>
       <PanelBody>
-        {loading ? (
-          <div className="panel-message">
-            {hasSearchQuery ? 'Searching…' : 'Loading…'}
-          </div>
-        ) : (
+        {hasProposals ? (
           <ProposalListTable
             fieldNames={fieldNames}
             proposals={proposals}
             columns={DEFAULT_COLUMNS}
             wrap={wrap}
           />
+        ) : (
+          <div className="panel-message">
+            {generateFallbackMessage()}
+          </div>
         )}
       </PanelBody>
     </Panel>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -4,6 +4,8 @@ import { useParams } from 'react-router-dom';
 import {
   ApiBaseField,
   ApiProposal,
+  PROPOSALS_DEFAULT_COUNT,
+  PROPOSALS_DEFAULT_PAGE,
   useBaseFields,
   useProposal,
   useProposals,
@@ -24,7 +26,10 @@ interface ProposalListGridLoaderProps {
 const ProposalListGridLoader = (
   { baseFields }: ProposalListGridLoaderProps,
 ) => {
-  const proposals = useProposals('1', '1000');
+  const proposals = useProposals(
+    PROPOSALS_DEFAULT_PAGE,
+    PROPOSALS_DEFAULT_COUNT,
+  );
 
   if (baseFields === null || proposals === null) {
     return (

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -6,6 +6,7 @@ import {
   ApiProposal,
   PROPOSALS_DEFAULT_COUNT,
   PROPOSALS_DEFAULT_PAGE,
+  PROPOSALS_DEFAULT_QUERY,
   useBaseFields,
   useProposal,
   useProposals,
@@ -29,6 +30,7 @@ const ProposalListGridLoader = (
   const proposals = useProposals(
     PROPOSALS_DEFAULT_PAGE,
     PROPOSALS_DEFAULT_COUNT,
+    PROPOSALS_DEFAULT_QUERY,
   );
 
   if (baseFields === null || proposals === null) {

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -4,6 +4,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   ApiBaseField,
   ApiProposal,
+  PROPOSALS_DEFAULT_COUNT,
+  PROPOSALS_DEFAULT_PAGE,
   useBaseFields,
   useProposals,
 } from '../pdc-api';
@@ -24,8 +26,8 @@ const fieldValueMatches = (proposal: ApiProposal, query: string) => (
 const ProposalListLoader = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
-  const page = params.get('page') ?? '1';
-  const count = params.get('count') ?? '1000';
+  const page = params.get('page') ?? PROPOSALS_DEFAULT_PAGE;
+  const count = params.get('count') ?? PROPOSALS_DEFAULT_COUNT;
   const query = params.get('q') ?? '';
   const fields = useBaseFields();
   const proposals = useProposals(page, count);

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -3,9 +3,9 @@ import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   ApiBaseField,
-  ApiProposal,
   PROPOSALS_DEFAULT_COUNT,
   PROPOSALS_DEFAULT_PAGE,
+  PROPOSALS_DEFAULT_QUERY,
   useBaseFields,
   useProposals,
 } from '../pdc-api';
@@ -17,20 +17,14 @@ const mapFieldNames = (fields: ApiBaseField[]) => Object.fromEntries(
   fields.map(({ label, shortCode }) => [shortCode, label]),
 );
 
-const fieldValueMatches = (proposal: ApiProposal, query: string) => (
-  proposal.versions[0]?.fieldValues.some(
-    ({ value }) => value.toLowerCase().includes(query.toLowerCase()),
-  )
-);
-
 const ProposalListLoader = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const page = params.get('page') ?? PROPOSALS_DEFAULT_PAGE;
   const count = params.get('count') ?? PROPOSALS_DEFAULT_COUNT;
-  const query = params.get('q') ?? '';
+  const query = params.get('q') ?? PROPOSALS_DEFAULT_QUERY;
   const fields = useBaseFields();
-  const proposals = useProposals(page, count);
+  const proposals = useProposals(page, count, query);
 
   useEffect(() => {
     document.title = 'Proposal List - Philanthropy Data Commons';
@@ -44,7 +38,7 @@ const ProposalListLoader = () => {
 
   const mappedProposals = mapProposals(
     fields,
-    proposals.entries.filter((p) => fieldValueMatches(p, query)),
+    proposals.entries,
   );
 
   return (

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -30,9 +30,21 @@ const ProposalListLoader = () => {
     document.title = 'Proposal List - Philanthropy Data Commons';
   }, []);
 
+  const handleSearch = (q: string) => navigate(`/proposals?q=${q}`);
+
   if (fields === null || proposals === null) {
     return (
-      <div>Loading data...</div>
+      <PanelGrid>
+        <PanelGridItem>
+          <ProposalListTablePanel
+            fieldNames={{}}
+            proposals={[]}
+            searchQuery={query}
+            onSearch={handleSearch}
+            loading
+          />
+        </PanelGridItem>
+      </PanelGrid>
     );
   }
 
@@ -48,7 +60,7 @@ const ProposalListLoader = () => {
           fieldNames={mapFieldNames(fields)}
           proposals={mappedProposals}
           searchQuery={query}
-          onSearch={(q) => navigate(`/proposals?q=${q}`)}
+          onSearch={handleSearch}
         />
       </PanelGridItem>
     </PanelGrid>

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -26,6 +26,7 @@ const usePdcApi = <T>(
   const [response, setResponse] = useState(null);
 
   useEffect(() => {
+    setResponse(null);
     const url = new URL(path, API_URL);
     url.search = params.toString();
     fetch(url)

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -87,13 +87,15 @@ interface ApiProposals {
 
 const PROPOSALS_DEFAULT_PAGE = '1';
 const PROPOSALS_DEFAULT_COUNT = '1000';
+const PROPOSALS_DEFAULT_QUERY = '';
 
-const useProposals = (page: string, count: string) => (
+const useProposals = (page: string, count: string, query: string) => (
   usePdcApi<ApiProposals>(
     '/proposals',
     new URLSearchParams({
       _page: page,
       _count: count,
+      _content: query,
     }),
   )
 );
@@ -101,6 +103,7 @@ const useProposals = (page: string, count: string) => (
 export {
   PROPOSALS_DEFAULT_COUNT,
   PROPOSALS_DEFAULT_PAGE,
+  PROPOSALS_DEFAULT_QUERY,
   useBaseFields,
   useProposal,
   useProposals,

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -85,6 +85,9 @@ interface ApiProposals {
   total: number;
 }
 
+const PROPOSALS_DEFAULT_PAGE = '1';
+const PROPOSALS_DEFAULT_COUNT = '1000';
+
 const useProposals = (page: string, count: string) => (
   usePdcApi<ApiProposals>(
     '/proposals',
@@ -96,6 +99,8 @@ const useProposals = (page: string, count: string) => (
 );
 
 export {
+  PROPOSALS_DEFAULT_COUNT,
+  PROPOSALS_DEFAULT_PAGE,
   useBaseFields,
   useProposal,
   useProposals,


### PR DESCRIPTION
Rather than always loading the full list of proposals from the API and doing basic string matching locally, instead use the recently introduced search API. The server search API includes such fanciness as word stemming (so that a query for "summaries" would match a proposal containing "summary") and operators (like "a OR b" which would match proposals containing either).

Note that we have not yet implemented pagination, so this is somewhat of a tradeoff: the initial page load will get the full list of proposals, and searching will cause another server round trip, and clearing the search will cause a third round trip. However, this is a necessary step on the way to pagination.

This should not be deployed (read: merged) until https://github.com/PhilanthropyDataCommons/service/pull/320 and https://github.com/PhilanthropyDataCommons/service/pull/337 have been deployed.

Issue #15 Implement pagination on proposal lists
Issue #83 Enable search
Issue #115 Show message on "no results" searches