### PR TITLE
Filter blank proposal values

### DIFF
--- a/src/map-proposals.test.ts
+++ b/src/map-proposals.test.ts
@@ -1,0 +1,93 @@
+import {
+  ApiCanonicalField,
+  ApiProposal,
+} from './pdc-api';
+import { mapProposals } from './map-proposals';
+
+const canonicalFields: ApiCanonicalField[] = [
+  {
+    id: 1,
+    label: 'Organization Name',
+    shortCode: 'organization_name',
+  },
+  {
+    id: 2,
+    label: 'Organization City',
+    shortCode: 'organization_city',
+  },
+  {
+    id: 3,
+    label: 'Organization Contact',
+    shortCode: 'organization_contact',
+  },
+  {
+    id: 4,
+    label: 'Organization Budget',
+    shortCode: 'organization_budget',
+  },
+];
+
+const apiProposals: ApiProposal[] = [
+  {
+    id: 1,
+    versions: [
+      {
+        version: 1,
+        fieldValues: [
+          {
+            value: 'Community Foundation',
+            applicationFormField: {
+              canonicalFieldId: 1,
+              position: 0,
+            },
+          },
+          {
+            value: 'Chicago',
+            applicationFormField: {
+              canonicalFieldId: 2,
+              position: 1,
+            },
+          },
+          {
+            value: 'John Doe',
+            applicationFormField: {
+              canonicalFieldId: 3,
+              position: 2,
+            },
+          },
+          {
+            value: ' ', // Intentionally blank for testing
+            applicationFormField: {
+              canonicalFieldId: 4,
+              position: 3,
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const mappedProposals = mapProposals(canonicalFields, apiProposals);
+
+test('maps the proposals', () => {
+  expect(mappedProposals.length).toBe(apiProposals.length);
+});
+
+test('maps the proposal ID', () => {
+  expect(mappedProposals[0]?.id).toBe(apiProposals[0]?.id.toString());
+});
+
+test('maps values to the expected place', () => {
+  const targetCanonicalField = 'organization_name';
+
+  const targetCanonicalFieldId = canonicalFields
+    .find((field) => field.shortCode === targetCanonicalField)?.id;
+  const proposalFieldValueIndex = apiProposals[0]?.versions[0]?.fieldValues
+    .findIndex((fieldValue) => (
+      fieldValue.applicationFormField.canonicalFieldId === targetCanonicalFieldId
+    ));
+
+  expect(mappedProposals[0]?.values[targetCanonicalField]?.[0])
+    .toEqual(apiProposals[0]?.versions[0]?.fieldValues[proposalFieldValueIndex ?? -1]?.value);
+});

--- a/src/map-proposals.test.ts
+++ b/src/map-proposals.test.ts
@@ -91,3 +91,7 @@ test('maps values to the expected place', () => {
   expect(mappedProposals[0]?.values[targetCanonicalField]?.[0])
     .toEqual(apiProposals[0]?.versions[0]?.fieldValues[proposalFieldValueIndex ?? -1]?.value);
 });
+
+test('does not map blank values', () => {
+  expect(mappedProposals[0]?.values.organization_budget).toBeUndefined();
+});

--- a/src/map-proposals.ts
+++ b/src/map-proposals.ts
@@ -20,6 +20,7 @@ const mapProposals = (fields: ApiCanonicalField[], proposals: ApiProposal[]) => 
         value,
       ])
         .filter((pair): pair is [string, string] => !!pair[0])
+        .filter((pair) => (pair[1].trim() !== ''))
         .reduce(extendMultimapReducer, {})
     ),
   }))


### PR DESCRIPTION
_This PR is an extraction of work and discussion from #101. It essentially replaces both #101 and #102._

This PR adds mock data and tests for the `mapProposals()` function, and then modifies that function to filter out blank strings when mapping API data to our internal data structure for proposal lists.

**Testing:**
1. `npm run test`
2. If you'd like, too, you can remove the `.filter((pair) => (pair[1].trim() !== ''))` line to see the test fail.
3. As this actually resolves the sidebar issue in #100, you can also `npm start` and load up a proposal detail page; no more proposals in the sidebar should have blank organization names.

**Incidentally…**

The intention of this PR was to extract some [great advice](https://github.com/PhilanthropyDataCommons/data-viewer/pull/101#discussion_r1185597861) from @jasonaowen in his review of #101, then rewrite #102 to use it. But after doing this work, I realized #102 (and the whole "get best proposal values from a list of keys" approach) was becoming a whole lot of code to add very little syntactic sugar, and that filtering blank values at the source (as this PR demonstrates) actually solves the problem without further changes needed.

Closes #100