### PR TITLE
Rename canonical fields to base fields

### DIFF
--- a/src/map-proposals.test.ts
+++ b/src/map-proposals.test.ts
@@ -1,10 +1,10 @@
 import {
-  ApiCanonicalField,
+  ApiBaseField,
   ApiProposal,
 } from './pdc-api';
 import { mapProposals } from './map-proposals';
 
-const canonicalFields: ApiCanonicalField[] = [
+const baseFields: ApiBaseField[] = [
   {
     id: 1,
     label: 'Organization Name',
@@ -37,28 +37,28 @@ const apiProposals: ApiProposal[] = [
           {
             value: 'Community Foundation',
             applicationFormField: {
-              canonicalFieldId: 1,
+              baseFieldId: 1,
               position: 0,
             },
           },
           {
             value: 'Chicago',
             applicationFormField: {
-              canonicalFieldId: 2,
+              baseFieldId: 2,
               position: 1,
             },
           },
           {
             value: 'John Doe',
             applicationFormField: {
-              canonicalFieldId: 3,
+              baseFieldId: 3,
               position: 2,
             },
           },
           {
             value: ' ', // Intentionally blank for testing
             applicationFormField: {
-              canonicalFieldId: 4,
+              baseFieldId: 4,
               position: 3,
             },
           },
@@ -68,7 +68,7 @@ const apiProposals: ApiProposal[] = [
   },
 ];
 
-const mappedProposals = mapProposals(canonicalFields, apiProposals);
+const mappedProposals = mapProposals(baseFields, apiProposals);
 
 test('maps the proposals', () => {
   expect(mappedProposals.length).toBe(apiProposals.length);
@@ -79,16 +79,16 @@ test('maps the proposal ID', () => {
 });
 
 test('maps values to the expected place', () => {
-  const targetCanonicalField = 'organization_name';
+  const targetBaseField = 'organization_name';
 
-  const targetCanonicalFieldId = canonicalFields
-    .find((field) => field.shortCode === targetCanonicalField)?.id;
+  const targetBaseFieldId = baseFields
+    .find((field) => field.shortCode === targetBaseField)?.id;
   const proposalFieldValueIndex = apiProposals[0]?.versions[0]?.fieldValues
     .findIndex((fieldValue) => (
-      fieldValue.applicationFormField.canonicalFieldId === targetCanonicalFieldId
+      fieldValue.applicationFormField.baseFieldId === targetBaseFieldId
     ));
 
-  expect(mappedProposals[0]?.values[targetCanonicalField]?.[0])
+  expect(mappedProposals[0]?.values[targetBaseField]?.[0])
     .toEqual(apiProposals[0]?.versions[0]?.fieldValues[proposalFieldValueIndex ?? -1]?.value);
 });
 

--- a/src/map-proposals.ts
+++ b/src/map-proposals.ts
@@ -1,4 +1,4 @@
-import type { ApiCanonicalField, ApiProposal } from './pdc-api';
+import type { ApiBaseField, ApiProposal } from './pdc-api';
 
 const extendMultimapReducer = (
   multimap: Record<string, string[]>,
@@ -8,15 +8,15 @@ const extendMultimapReducer = (
   ...multimap,
 });
 
-const mapProposals = (fields: ApiCanonicalField[], proposals: ApiProposal[]) => (
+const mapProposals = (fields: ApiBaseField[], proposals: ApiProposal[]) => (
   proposals.map((proposal) => ({
     id: proposal.id.toString(),
     values: (
       (proposal.versions[0]?.fieldValues ?? []).map(({
-        applicationFormField: { canonicalFieldId },
+        applicationFormField: { baseFieldId },
         value,
       }) => [
-        fields.find(({ id }) => (id === canonicalFieldId))?.shortCode,
+        fields.find(({ id }) => (id === baseFieldId))?.shortCode,
         value,
       ])
         .filter((pair): pair is [string, string] => !!pair[0])

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -2,16 +2,16 @@ import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
-  ApiCanonicalField,
+  ApiBaseField,
   ApiProposal,
-  useCanonicalFields,
+  useBaseFields,
   useProposals,
 } from '../pdc-api';
 import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
 
-const mapFieldNames = (fields: ApiCanonicalField[]) => Object.fromEntries(
+const mapFieldNames = (fields: ApiBaseField[]) => Object.fromEntries(
   fields.map(({ label, shortCode }) => [shortCode, label]),
 );
 
@@ -27,7 +27,7 @@ const ProposalListLoader = () => {
   const page = params.get('page') ?? '1';
   const count = params.get('count') ?? '1000';
   const query = params.get('q') ?? '';
-  const fields = useCanonicalFields();
+  const fields = useBaseFields();
   const proposals = useProposals(page, count);
 
   useEffect(() => {

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -49,13 +49,13 @@ const usePdcApi = <T>(
   return response;
 };
 
-interface ApiCanonicalField {
+interface ApiBaseField {
   id: number;
   label: string;
   shortCode: string;
 }
 
-const useCanonicalFields = () => usePdcApi<ApiCanonicalField[]>('/canonicalFields');
+const useBaseFields = () => usePdcApi<ApiBaseField[]>('/baseFields');
 
 interface ApiProposal {
   id: number;
@@ -63,7 +63,7 @@ interface ApiProposal {
     version: number;
     fieldValues: {
       applicationFormField: {
-        canonicalFieldId: number;
+        baseFieldId: number;
         position: number;
       };
       value: string;
@@ -96,12 +96,12 @@ const useProposals = (page: string, count: string) => (
 );
 
 export {
-  useCanonicalFields,
+  useBaseFields,
   useProposal,
   useProposals,
 };
 
 export type {
-  ApiCanonicalField,
+  ApiBaseField,
   ApiProposal,
 };


### PR DESCRIPTION
Update the names in our code to follow the rename from "canonical fields" to "base fields", including the API endpoint. The user-facing strings used in the UI were previously changed in PR #105.

This must be deployed in coordination with https://github.com/PhilanthropyDataCommons/service/pull/334 , as deploying one without the other will break the front-end.

Issue https://github.com/PhilanthropyDataCommons/service/issues/275