### PR TITLE
Fix applicant name display

### DIFF
--- a/src/components/ProposalListGridItem.css
+++ b/src/components/ProposalListGridItem.css
@@ -17,11 +17,11 @@
   border-bottom: none;
 }
 
-.proposal--organization-name {
+.proposal--applicant-name {
   font-weight: var(--font-weight--medium);
 }
 
-.proposal--organization-address,
+.proposal--applicant-address,
 .proposal--proposal-name {
   color: var(--color--gray--medium-dark);
   font-size: 0.9em;

--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -9,9 +9,9 @@ interface ProposalListGridItemProps {
 }
 
 export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) => {
-  const organizationName = getPreferredApplicantNameValues(proposal);
+  const applicantName = getPreferredApplicantNameValues(proposal);
 
-  const organizationLocation = ['organization_city', 'organization_state_province', 'organization_country']
+  const applicantLocation = ['organization_city', 'organization_state_province', 'organization_country']
     .map((key) => proposal.values[key]?.filter((value) => value !== '')) // Filter out blank strings
     .filter((value) => (value ?? []).length > 0) // Filter out empty value arrays
     .join(', ');
@@ -21,12 +21,12 @@ export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) =>
       to={`/proposals/${proposal.id}`}
       className="proposal-list-grid-item"
     >
-      <div className="proposal--organization-name">
-        {organizationName}
+      <div className="proposal--applicant-name">
+        {applicantName}
       </div>
-      {organizationLocation ? (
-        <div className="proposal--organization-address">
-          {organizationLocation}
+      {applicantLocation ? (
+        <div className="proposal--applicant-address">
+          {applicantLocation}
         </div>
       ) : null}
       {proposal.values.proposal_name ? (

--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { getPreferredApplicantNameValues } from '../utils/proposals';
 import './ProposalListGridItem.css';
 
 interface ProposalListGridItemProps {
@@ -8,12 +9,7 @@ interface ProposalListGridItemProps {
 }
 
 export const ProposalListGridItem = ({ proposal }: ProposalListGridItemProps) => {
-  const organizationName = proposal.values.organization_name
-    ?? proposal.values.organization_dba_name
-    ?? proposal.values.organization_legal_name
-    ?? proposal.values.proposal_primary_contact_name
-    ?? proposal.values.proposal_submitter_name
-    ?? 'Unknown Applicant';
+  const organizationName = getPreferredApplicantNameValues(proposal);
 
   const organizationLocation = ['organization_city', 'organization_state_province', 'organization_country']
     .map((key) => proposal.values[key]?.filter((value) => value !== '')) // Filter out blank strings

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { getPreferredApplicantNameValues } from '../utils/proposals';
 import {
   Table,
   TableHead,
@@ -25,12 +26,26 @@ const ProposalListTableRow = ({
     navigate(`/proposals/${proposal.id}`);
   };
 
+  const getProposalCellContents = (shortCode: string) => {
+    let proposalValue;
+
+    switch (shortCode) {
+      case 'organization_name':
+        proposalValue = getPreferredApplicantNameValues(proposal);
+        break;
+      default:
+        proposalValue = proposal.values[shortCode];
+    }
+
+    return proposalValue;
+  };
+
   return (
     <TableRow onClick={handleRowClick}>
       {/* Iterate over columns to ensure order. */}
       {columns.map((shortCode) => (
         <RowCell key={shortCode}>
-          {proposal.values[shortCode]}
+          {getProposalCellContents(shortCode)}
         </RowCell>
       ))}
     </TableRow>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -12,6 +12,10 @@ import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
 import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
+import {
+  PROPOSAL_APPLICANT_NAME_CASCADE,
+  PROPOSAL_APPLICANT_NAME_FALLBACK,
+} from '../utils/proposals';
 
 interface ProposalListGridLoaderProps {
   baseFields: ApiBaseField[] | null;
@@ -74,14 +78,13 @@ const mapBaseFields = (
 const getApplicant = (
   baseFields: ApiBaseField[],
   proposal: ApiProposal,
-) => (
-  getValueOfBaseField(baseFields, proposal, 'organization_name')
-    ?? getValueOfBaseField(baseFields, proposal, 'organization_dba_name')
-    ?? getValueOfBaseField(baseFields, proposal, 'organization_legal_name')
-    ?? getValueOfBaseField(baseFields, proposal, 'proposal_primary_contact_name')
-    ?? getValueOfBaseField(baseFields, proposal, 'proposal_submitter_name')
-    ?? 'Unknown Applicant'
-);
+) => {
+  const applicantNameKey = PROPOSAL_APPLICANT_NAME_CASCADE
+    .find((key) => typeof getValueOfBaseField(baseFields, proposal, key) !== 'undefined');
+
+  return applicantNameKey ? (getValueOfBaseField(baseFields, proposal, applicantNameKey)
+    ?? PROPOSAL_APPLICANT_NAME_FALLBACK) : PROPOSAL_APPLICANT_NAME_FALLBACK;
+};
 
 interface ProposalDetailPanelLoaderProps {
   baseFields: ApiBaseField[] | null;

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -80,7 +80,10 @@ const getApplicant = (
   proposal: ApiProposal,
 ) => {
   const applicantNameKey = PROPOSAL_APPLICANT_NAME_CASCADE
-    .find((key) => typeof getValueOfBaseField(baseFields, proposal, key) !== 'undefined');
+    .find((key) => {
+      const baseFieldValue = getValueOfBaseField(baseFields, proposal, key);
+      return typeof baseFieldValue !== 'undefined' && baseFieldValue.trim() !== '';
+    });
 
   return applicantNameKey ? (getValueOfBaseField(baseFields, proposal, applicantNameKey)
     ?? PROPOSAL_APPLICANT_NAME_FALLBACK) : PROPOSAL_APPLICANT_NAME_FALLBACK;

--- a/src/utils/proposals.test.ts
+++ b/src/utils/proposals.test.ts
@@ -1,0 +1,46 @@
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import {
+  getPreferredApplicantNameValues,
+  PROPOSAL_APPLICANT_NAME_CASCADE,
+  PROPOSAL_APPLICANT_NAME_FALLBACK,
+} from './proposals';
+
+const proposal = {
+  id: '123',
+  values: {
+    organization_name: ['Org Name'],
+    organization_dba_name: ['Org DBA Name'],
+    organization_legal_name: ['Org Legal Name'],
+    proposal_primary_contact_name: ['Proposal Contact Name'],
+    proposal_submitter_name: ['Proposal Submitter Name'],
+  },
+} as DataViewerProposal;
+
+test('can select most preferred applicant name', () => {
+  const mostPreferredNameKey = PROPOSAL_APPLICANT_NAME_CASCADE[0] ?? '';
+
+  expect(getPreferredApplicantNameValues(proposal)).toEqual(proposal.values[mostPreferredNameKey]);
+});
+
+test('can cascade through preferred applicant names', () => {
+  const leastPreferredNameKey = PROPOSAL_APPLICANT_NAME_CASCADE.at(-1) ?? '';
+  const leastPreferredNameValues = ['ABC'];
+  const leastPreferredProposal = {
+    id: '123',
+    values: {
+      [leastPreferredNameKey]: leastPreferredNameValues,
+    },
+  } as DataViewerProposal;
+
+  expect(getPreferredApplicantNameValues(leastPreferredProposal)).toEqual(leastPreferredNameValues);
+});
+
+test('can fall back to fallback applicant name', () => {
+  const blankProposal = {
+    id: '123',
+    values: {},
+  } as DataViewerProposal;
+
+  expect(getPreferredApplicantNameValues(blankProposal))
+    .toEqual([PROPOSAL_APPLICANT_NAME_FALLBACK]);
+});

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -1,0 +1,38 @@
+import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+
+const PROPOSAL_APPLICANT_NAME_CASCADE = [
+  'organization_name',
+  'organization_dba_name',
+  'organization_legal_name',
+  'proposal_primary_contact_name',
+  'proposal_submitter_name',
+];
+
+const PROPOSAL_APPLICANT_NAME_FALLBACK = 'Unknown Applicant';
+
+/**
+   * Proposals may store the applicant name in one of several fields.
+   * This utility returns iterates through the list of attributes where
+   * we expect to find a name, in a preferential order, and returns the
+   * first matching value.
+   *
+   * If none is found, falls back to the fallback value.
+   *
+   * @param  {DataViewerProposal} proposal
+   * @return {(Array)} The applicant name value array.
+   */
+const getPreferredApplicantNameValues = (proposal: DataViewerProposal) => {
+  const bestNameKey = PROPOSAL_APPLICANT_NAME_CASCADE.find((key) => proposal.values[key]);
+
+  if (bestNameKey) {
+    return proposal.values[bestNameKey];
+  }
+
+  return [PROPOSAL_APPLICANT_NAME_FALLBACK];
+};
+
+export {
+  PROPOSAL_APPLICANT_NAME_CASCADE,
+  PROPOSAL_APPLICANT_NAME_FALLBACK,
+  getPreferredApplicantNameValues,
+};


### PR DESCRIPTION
_This PR changes some LOC that contain the "canonical" terminology changed by #113. Whichever PR is merged into `main` first — and I assume it's #113 but that's dependent on the API deployment — will cause conflicts with the other. That's fine, we'll resolve._

#112 resolved display of applicant name in the sidebar, but as documented in #109, there were still two more places that blank-string applicant names could mess up display:

- In the proposal list table's "Organization Name" column
- In the panel header atop proposal detail pages (and the `<title>` of that page)

This PR resolves both remaining places. It introduces a `getPreferredApplicantNameValues()` utility (yes, similar to the `getProposalValuesFromCandidates()` utility that I abandoned earlier) + tests, uses it, and then uses a separate method of resolving the issue on panel headers where we don't use the `DataViewerProposal` data structure.

**Testing:**
- Switch to `main`, fire up the app, and notice that…
   - The proposal list table (`/proposals`) contains a bunch of blank Organization Names
   - Some proposals (e.g., `/proposals/406` on the production API) are missing a title in the panel header.
- Switch to this branch and check those pages again. Now each should have data where once there was none!
- And of course, `npm run test`

Closes #109 