### PR TITLE
Cleanup some React App boilerplate

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,11 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>Philanthropy Data Commons Data Viewer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#343434" />
     <meta
       name="description"
       content="Displays the data in the Philanthropy Data Commons pilot. Read more at philanthropydatacommons.org."

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Displays the data in the Philanthropy Data Commons pilot. Read more at philanthropydatacommons.org."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "PDC Pilot",
+  "name": "Philanthropy Data Commons Pilot Data Viewer",
   "icons": [
     {
       "src": "favicon.ico",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#343434",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
While preparing to tackle #71, I discovered a few Create React App boilerplate bits and pieces that deserved a quick cleanup but that I didn't want to muss up that impending PR with. So here they are.

This primarily removes some HTML comments that we don't need to be shipping to users (although I'm miffed we don't have a good place in our README for the `%PUBLIC_URL%` explanation, though it's easily Googleable) and corrects names/description metadata.

I considered just removing the WebManifest file because we have no intention of maintaining this as a mobile web PWA, but I can't convince myself of that.