### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Use GitHub's Dependabot to help us with [version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates). This should help us keep up to date more effectively by automatically opening a PR when a new version is available, linking to the release notes, running CI, and - most importantly - reminding us that this maintenance needs to be done.

This configuration was mostly borrowed from the [configuration used in the service repo](https://github.com/PhilanthropyDataCommons/service/blob/d7d5b5f169cc428d5aee53f79489f65a80d97464/.github/dependabot.yml).