### PR TITLE
Don't cascade `proposal_name` to other fields

### DIFF
--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -26,19 +26,9 @@ const ProposalListTableRow = ({
     navigate(`/proposals/${proposal.id}`);
   };
 
-  const getProposalCellContents = (shortCode: string) => {
-    let proposalValue;
-
-    switch (shortCode) {
-      case 'organization_name':
-        proposalValue = getPreferredApplicantNameValues(proposal);
-        break;
-      default:
-        proposalValue = proposal.values[shortCode];
-    }
-
-    return proposalValue;
-  };
+  const getProposalCellContents = (shortCode: string) => (shortCode === 'organization_name'
+    ? getPreferredApplicantNameValues(proposal)
+    : proposal.values[shortCode]);
 
   return (
     <TableRow onClick={handleRowClick}>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -125,8 +125,7 @@ const ProposalDetailPanelLoader = (
     );
   }
 
-  const title = getValueOfBaseField(baseFields, proposal, 'proposal_name')
-    ?? getValueOfBaseField(baseFields, proposal, 'proposal_title');
+  const title = getValueOfBaseField(baseFields, proposal, 'proposal_name');
   const applicant = getApplicant(baseFields, proposal);
   const applicantId = getValueOfBaseField(baseFields, proposal, 'organization_tax_id');
   const version = proposal.versions[0]?.version ?? 0;


### PR DESCRIPTION
This PR simplifies our display of `proposal_name` from a cascade to other fields to just a simple field display.

Because of this change, I went ahead and made the simplification @jasonaowen [suggested](https://github.com/PhilanthropyDataCommons/data-viewer/pull/114#discussion_r1192764099) in his review of #114.

**Testing:**

The cascade that this PR removes wasn't working as designed anyway, since the field that `proposal_name` was falling back to (`proposal_title`) [had already been renamed](https://github.com/PhilanthropyDataCommons/service/issues/284#issuecomment-1531799718) without the viewer knowing / being updated. (Oops.) Thus, there's no A/B (`main` / this branch) comparison you can make to prove anything.

So: just load up the proposal detail page for any proposal with a `proposal_name` (e.g., 424 from the production API) and make sure the proposal name is displayed in the panel header as shown below:

<img width="403" alt="image" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/32febe55-0690-44ff-b130-dd06a1b7b742">

Closes #120 

