### PR TITLE
Use types for Node.js 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.2",
-        "@types/node": "^16.18.12",
+        "@types/node": "^18.16.17",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "babel-plugin-named-exports-order": "^0.0.2",
@@ -4926,6 +4926,12 @@
         }
       }
     },
+    "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
+    },
     "node_modules/@storybook/builder-webpack5/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -5471,6 +5477,12 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/core-common/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
+    },
     "node_modules/@storybook/core-common/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5690,6 +5702,12 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
+    },
     "node_modules/@storybook/core-server/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5811,6 +5829,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       }
+    },
+    "node_modules/@storybook/core-webpack/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
     },
     "node_modules/@storybook/csf": {
       "version": "0.1.0",
@@ -6140,6 +6164,12 @@
         }
       }
     },
+    "node_modules/@storybook/preset-react-webpack/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
+    },
     "node_modules/@storybook/preset-react-webpack/node_modules/fs-extra": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -6301,10 +6331,22 @@
         }
       }
     },
+    "node_modules/@storybook/react-webpack5/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "dev": true
+    },
     "node_modules/@storybook/react/node_modules/@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "node_modules/@storybook/react/node_modules/@types/node": {
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
       "dev": true
     },
     "node_modules/@storybook/react/node_modules/acorn": {
@@ -7605,9 +7647,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
-      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==",
+      "version": "18.16.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.17.tgz",
+      "integrity": "sha512-QAkjjRA1N7gPJeAP4WLXZtYv6+eMXFNviqktCDt4GLcmCugMr5BcRHfkOjCQzvCsnMp+L79a54zBkbw356xv9Q==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.2",
-    "@types/node": "^16.18.12",
+    "@types/node": "^18.16.17",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "babel-plugin-named-exports-order": "^0.0.2",


### PR DESCRIPTION
When we enabled Dependabot version upgrades in this repo, one of the first things it did was hassle us about `@types/node`: #125. That brought to my attention the fact we were using the wrong version of `@types/node`, given that we're targeting Node.js 18, so fix that, and also configure Dependabot not to give us major version upgrades for that package.