### PR TITLE
Add Dropdown component and story

### DIFF
--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -1,0 +1,115 @@
+:root {
+  --dropdown--menu--border-radius: 8px;
+  --dropdown--menu--spacing: var(--accessible-spacing--1x);
+  --dropdown--menu-item--icon-size: 1.5em;
+}
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-trigger {
+  /* Hide the disclosure triangle that is natively applied to `<summary>` elements.
+     This is already implicit because the dropdown-trigger has the `.button` class applied,
+     which class specifies the `all: unset` property that has this same effect.
+     However, we shouldn't rely on that implicit effect,
+     so here we make our intention explicit. */
+  list-style: none;
+}
+
+/* Safari hack: Safari doesn't respect the above method of hiding the disclosure triangle. */
+.dropdown-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown[open] > .dropdown-trigger {
+  --button--primary-color: var(--color--blue);
+  --button--contrast-color: var(--color--gray--lighter);
+}
+
+/* This generates an invisible backdrop when the dropdown is open,
+   behind the dropdown but above all other page content,
+   that is technically part of the dropdown trigger.
+   Thus, clicking anywhere else on the page is like clicking the trigger,
+   and closes the dropdown. */
+.dropdown[open] > .dropdown-trigger::before {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  content: ' ';
+  display: block;
+  cursor: default;
+}
+
+.dropdown-menu {
+  position: absolute;
+  z-index: 100;
+  width: 30ch;
+
+  background-color: white;
+  border-radius: 8px;
+  border: 1px solid var(--color--gray--medium);
+  overflow: hidden;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown.dropdown--left > .dropdown-menu {
+  left: 0;
+}
+
+.dropdown.dropdown--right > .dropdown-menu {
+  right: 0;
+}
+
+.dropdown-menu > * {
+  border-bottom: 1px solid var(--color--gray--light);
+}
+
+.dropdown-menu > *:last-child {
+  border-bottom: none;
+}
+
+/* CSS `transition` doesn't work when disclosing `<details>` element contents,
+  thus we use `animation`. */
+@keyframes show-dropdown-menu {
+  from {
+    opacity: 0;
+    transform: translateY(0);
+  }
+}
+
+.dropdown[open] .dropdown-menu {
+  animation: show-dropdown-menu 200ms ease-in-out;
+
+  opacity: 1;
+  transform: translateY(10px);
+}
+
+.dropdown-menu-text {
+  font-size: 0.85rem;
+  padding: var(--dropdown--menu--spacing);
+}
+
+.dropdown-menu-link {
+  color: inherit;
+  font-weight: var(--font-weight--medium);
+  text-decoration: none;
+  padding: var(--dropdown--menu--spacing);
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--fixed-spacing--2x);
+}
+
+.dropdown-menu-link:hover {
+  background-color: var(--color--gray--lighter);
+}
+
+.dropdown-menu-link > svg {
+  height: var(--dropdown--menu-item--icon-size);
+  width: var(--dropdown--menu-item--icon-size);
+}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import './Dropdown.css';
+// We use several `Button` classes and CSS variables.
+import '../Button.css';
+
+interface DropdownMenuProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A menu that is only visible when its `Dropdown` parent has an `open` attribute.
+ */
+const DropdownMenu = ({
+  children,
+  className = '',
+}: DropdownMenuProps) => (
+  <div className={`dropdown-menu ${className}`.trim()}>
+    {children}
+  </div>
+);
+
+interface DropdownProps {
+  /**
+   * Children will be rendered as the contents of the dropdown menu itself.
+   * These are expected — but not required — to be `DropdownMenuLink` or
+   * `DropdownMenuText` components.
+   */
+  children: React.ReactNode;
+  /**
+   * Content for the trigger button that toggles the menu.
+   * Can be text, components, HTML, etc.
+   */
+  trigger: React.ReactNode;
+  /**
+   * Should the menu be aligned to the left or right edge of its toggle?
+   */
+  align?: 'left' | 'right';
+  className?: string;
+}
+
+/**
+ * Accessible, JavaScript-free dropdowns using the `<details>` element.
+ */
+export const Dropdown = ({
+  children,
+  trigger,
+  align = 'left',
+  className = '',
+}: DropdownProps) => (
+  <details className={`dropdown dropdown--${align} ${className}`.trim()}>
+    <summary className="dropdown-trigger button button--bordered">
+      {trigger}
+    </summary>
+    <DropdownMenu>
+      {children}
+    </DropdownMenu>
+  </details>
+);

--- a/src/components/Dropdown/DropdownMenuLink.tsx
+++ b/src/components/Dropdown/DropdownMenuLink.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface DropdownMenuLinkProps {
+  /**
+   * Destination path or URL.
+   */
+  to: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A `<Link>` element inside a dropdown menu.
+ */
+export const DropdownMenuLink = ({
+  to,
+  children,
+  className = '',
+}: DropdownMenuLinkProps) => (
+  <Link to={to} className={`dropdown-menu-link ${className}`.trim()}>
+    {children}
+  </Link>
+);

--- a/src/components/Dropdown/DropdownMenuText.tsx
+++ b/src/components/Dropdown/DropdownMenuText.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface DropdownMenuTextProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Dropdown menu text introduce menu items,
+ * but can also be used as intermediate or footnote elements
+ * based on where in the markup they appear.
+ */
+export const DropdownMenuText = ({
+  children,
+  className = '',
+}: DropdownMenuTextProps) => (
+  <div className={`dropdown-menu-text ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,0 +1,9 @@
+import { Dropdown } from './Dropdown';
+import { DropdownMenuText } from './DropdownMenuText';
+import { DropdownMenuLink } from './DropdownMenuLink';
+
+export {
+  Dropdown,
+  DropdownMenuText,
+  DropdownMenuLink,
+};

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { ArrowRightOnRectangleIcon, ArrowUpOnSquareIcon } from '@heroicons/react/24/outline';
+
+import {
+  Dropdown,
+  DropdownMenuText,
+  DropdownMenuLink,
+} from '../components/Dropdown';
+
+const meta = {
+  component: Dropdown,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    trigger: 'Toggle menu',
+    children: [
+      <DropdownMenuLink to="/" key="item1">Item 1</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+    ],
+  },
+  // Storybook elements are placed inside `overflow:hidden` containers,
+  // which in our case causes the (absolutely-positioned) dropdown menu to render out of view.
+  // This wrapper ensures the element will be tall enough to display the menu.
+  // Subsequent stories will override it with their own height as needed.
+  decorators: [
+    (Story) => <div style={{ height: '200px' }}><Story /></div>,
+  ],
+};
+
+export const RightAligned: Story = {
+  args: {
+    align: 'right',
+    trigger: 'Toggle menu',
+    children: [
+      <DropdownMenuLink to="/" key="item1">Item 1</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div style={{
+        height: '200px',
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const WithIconInTrigger: Story = {
+  args: {
+    trigger: [
+      <ArrowUpOnSquareIcon />,
+      'Toggle menu',
+    ],
+    children: [
+      <DropdownMenuLink to="/" key="item1">Item 1</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+    ],
+  },
+  decorators: [
+    (Story) => <div style={{ height: '250px' }}><Story /></div>,
+  ],
+};
+
+export const WithMenuTitle: Story = {
+  args: {
+    trigger: 'Toggle menu',
+    children: [
+      <DropdownMenuText key="title1">Some optional explainer text for the menu items:</DropdownMenuText>,
+      <DropdownMenuLink to="/" key="item1">Item 1</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+    ],
+  },
+  decorators: [
+    (Story) => <div style={{ height: '250px' }}><Story /></div>,
+  ],
+};
+
+export const WithMultipleMenuTitles: Story = {
+  args: {
+    trigger: 'Toggle menu',
+    children: [
+      <DropdownMenuText key="title1">Some optional explainer text for the menu items:</DropdownMenuText>,
+      <DropdownMenuLink to="/" key="item1">Item 1</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+      <DropdownMenuText key="title2">…or mid-stream…</DropdownMenuText>,
+      <DropdownMenuLink to="/" key="item4">Item 4</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item5">Item 5</DropdownMenuLink>,
+      <DropdownMenuText key="title3">…or even at the end.</DropdownMenuText>,
+    ],
+  },
+  decorators: [
+    (Story) => <div style={{ height: '400px' }}><Story /></div>,
+  ],
+};
+
+export const WithMenuItemIcons: Story = {
+  args: {
+    trigger: 'Toggle menu',
+    children: [
+      <DropdownMenuLink to="/" key="item1">
+        Item 1
+        <ArrowRightOnRectangleIcon />
+      </DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item2">Item 2</DropdownMenuLink>,
+      <DropdownMenuLink to="/" key="item3">Item 3</DropdownMenuLink>,
+    ],
+  },
+  decorators: [
+    (Story) => <div style={{ height: '200px' }}><Story /></div>,
+  ],
+};


### PR DESCRIPTION
This PR adds a `Dropdown` component, used for generating dropdown menus from button-like triggers:

https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/2ab5c95a-0d36-4fbf-afe3-55897c2e5671

This implementation is specific to our current needs and doesn’t offer the flexibility one would want from a general-purpose dropdown library. That’s fine until we have more use cases.

**Testing:**

As this isn't yet implemented on any page, you'll need to run the Storybook to see it.

Issue #23 Create applicant detail page