### PR TITLE
Condense next/previous proposal buttons

### DIFF
--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -12,6 +12,7 @@ import {
   PanelTitleWrapper,
 } from './Panel';
 import { ProposalTable } from './ProposalTable';
+import { FormElementGroup } from './FormElementGroup';
 
 interface ProposalDetailPanelProps {
   title: string | undefined;
@@ -56,22 +57,22 @@ const ProposalDetailPanel = ({
       </PanelTitleWrapper>
       <PanelActions>
         {process.env.NODE_ENV !== 'production' && (
-          <>
+          <FormElementGroup>
             <Link
               to={`/proposals/${proposalId - 1}`}
               className="button button--color-gray"
+              title="Previous proposal"
             >
               <BackwardIcon className="icon" />
-              Previous
             </Link>
             <Link
               to={`/proposals/${proposalId + 1}`}
               className="button button--color-gray"
+              title="Next proposal"
             >
-              Next
               <ForwardIcon className="icon" />
             </Link>
-          </>
+          </FormElementGroup>
         )}
       </PanelActions>
     </PanelHeader>


### PR DESCRIPTION
For speedy dev navigation between proposals, we offer next/previous buttons on the proposal detail panel. These take up quite a lot of space, however.

This change condenses them by hiding the labels and using the `FormElementGroup` wrapper.

**Before:**
<img width="335" alt="Proposal navigation with labeled buttons" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/69ac8615-2ea5-4d92-896b-46e743121260">

**After:**
<img width="291" alt="Proposal navigation with icons only" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/a924ac8d-342d-4d33-95d1-859d34530a80">
