### PR TITLE
Allow table row headers to wrap but with min-width

### DIFF
--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -23,7 +23,7 @@
 }
 
 .table tbody th {
-  white-space: nowrap;
+  min-width: 25%;
 }
 
 .table th,


### PR DESCRIPTION
This PR replaces the draconian `white-space: nowrap` on row headers with a more sensible min-width of 25%.

While this may still not look perfect in all scenarios, it looks natural in all scenarios I tested it against, and avoids the problem where very long row headers can generate undesired layout.

**Before:**
<img width="1255" alt="before" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/987cf142-3224-4dc9-8f5f-e633fff8d82d">

**After:**
<img width="1255" alt="after" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/088ba4a1-adaf-4603-afc1-aa59e4df3702">

Closes #168 Long field labels break table formatting