### PR TITLE
Add data platform panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "@axa-fr/react-oidc": "^6.15.6",
         "@fontsource/source-sans-pro": "^5.0.2",
         "@heroicons/react": "^2.0.18",
+        "jsonpath-plus": "^7.2.0",
         "pino": "^8.14.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.2",
+        "title-case": "^3.0.3",
         "web-vitals": "^3.3.1"
       },
       "devDependencies": {
@@ -17017,6 +17019,14 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
@@ -22767,6 +22777,14 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -22904,8 +22922,7 @@
     "node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "@axa-fr/react-oidc": "^6.15.6",
     "@fontsource/source-sans-pro": "^5.0.2",
     "@heroicons/react": "^2.0.18",
+    "jsonpath-plus": "^7.2.0",
     "pino": "^8.14.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",
+    "title-case": "^3.0.3",
     "web-vitals": "^3.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,19 @@
       "project": "./tsconfig.json"
     },
     "rules": {
+      "@typescript-eslint/comma-dangle": [
+        "error",
+        {
+          "arrays": "always-multiline",
+          "objects": "always-multiline",
+          "imports": "always-multiline",
+          "exports": "always-multiline",
+          "functions": "only-multiline",
+          "enums": "always-multiline",
+          "generics": "always-multiline",
+          "tuples": "always-multiline"
+        }
+      ],
       "import/prefer-default-export": "off",
       "import/no-default-export": "error",
       "import/no-extraneous-dependencies": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => (
     <AppMain>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/proposals/:proposalId" element={<ProposalDetail />} />
+        <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
         <Route path="/proposals" element={<ProposalList />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,6 +29,7 @@ interface ButtonProps {
    * Sets the <button> type to "submit"
    */
   submit?: boolean;
+  title?: string;
 }
 
 /**
@@ -43,6 +44,7 @@ export const Button = ({
   disabled = false,
   onClick = (() => true),
   submit = false,
+  title = undefined,
 }: ButtonProps) => {
   const buttonClassNames = [
     'button',
@@ -67,6 +69,7 @@ export const Button = ({
       className={buttonClassNames.join(' ')}
       disabled={disabled}
       onClick={onClick}
+      title={title}
     >
       {children}
     </button>

--- a/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
@@ -1,13 +1,89 @@
 import React from 'react';
+import { JSONPath } from 'jsonpath-plus';
+import { titleCase } from 'title-case';
+import { useProviderData } from '../../pdc-api';
 import { ClosablePanel, PanelTitle } from '../Panel';
 import { DataPlatformProviderPanel } from './DataPlatformProviderPanel';
+
+interface JSONPathAll {
+  path: string;
+  pointer: string;
+  value: string;
+}
+
+const mapPathsToValues = (paths: string[][], data: object) => (
+  paths
+    .flatMap((path) => JSONPath<JSONPathAll>({
+      json: data,
+      path,
+      preventEval: true,
+      resultType: 'all',
+    }))
+    .map(({ path, pointer, value }) => ({
+      jsonPath: path,
+      fieldName: titleCase(
+        pointer
+          .substring(1)
+          .replace(/\//g, ': ')
+          .replace(/_/g, ' ')
+      ),
+      value,
+    }))
+    .filter(({ value }) => typeof value === 'string' && value.trim() != '')
+);
 
 const providers = {
   candid: {
     name: 'Candid',
+    parse: (data: object) => ({
+      applicant: JSONPath<string>({
+        json: data,
+        path: ['$', 'summary', 'organization_name'],
+        preventEval: true,
+        resultType: 'value',
+        wrap: false,
+      }),
+      url: JSONPath<string>({
+        json: data,
+        path: ['$', 'summary', 'gs_public_report'],
+        preventEval: true,
+        resultType: 'value',
+        wrap: false,
+      }),
+      values: mapPathsToValues([
+        ['$', 'summary', 'ein'],
+        ['$', 'summary', 'mission'],
+        ['$', 'summary', 'website_url'],
+        ['$', 'operations', 'blog_url'],
+        ['$', 'summary', 'telephone_numbers', '*', 'telephone_number'],
+        ['$', 'summary', 'social_media_urls', '*'],
+        ['$', 'summary', 'gs_profile_update_level'],
+        ['$', 'operations', 'leader_name'],
+        ['$', 'operations', 'leader_profile'],
+        ['$', 'operations', 'no_of_employees'],
+        ['$', 'operations', 'no_of_volunteers'],
+        ['$', 'operations', 'employees_greater_than_100K'],
+        ['$', 'operations', 'demographics', 'staff_level_totals', '*'],
+        ['$', 'operations', 'board_chair_name'],
+        ['$', 'operations', 'board_chair_affiliation'],
+        ['$', 'operations', 'board_of_directors', '*', 'name'],
+        ['$', 'summary', 'latitude'],
+        ['$', 'summary', 'longitude'],
+        ['$', 'summary', 'keywords'],
+        ['$', 'summary', 'ntee_code'],
+        ['$', 'summary', 'pcs_codes', '*', 'pcs_description'],
+        ['$', 'summary', 'profile_sdg_codes', '*', 'description'],
+        ['$', 'summary', 'addresses', '*', '*'],
+      ], data),
+    }),
   },
   'charity-navigator': {
     name: 'Charity Navigator',
+    parse: (data: object) => ({
+      applicant: 'todo',
+      url: 'todo',
+      values: [],
+    }),
   },
 };
 type KnownProvider = keyof typeof providers;
@@ -58,6 +134,22 @@ const Loading = ({
   </ClosablePanel>
 );
 
+const NoData = ({
+  onClose,
+  provider,
+}: ClosableKnownProviderProps) => (
+  <ClosablePanel
+    onClose={onClose}
+    title={(
+      <PanelTitle>
+        {providers[provider].name}
+      </PanelTitle>
+    )}
+  >
+    No data found
+  </ClosablePanel>
+);
+
 interface ProviderPanelLoaderProps {
   externalId: string;
   onClose: () => void;
@@ -68,36 +160,29 @@ const ProviderPanelLoader = ({
   externalId,
   onClose,
   provider,
-}: ProviderPanelLoaderProps) => (
-  <DataPlatformProviderPanel
-    applicant={externalId}
-    onClose={onClose}
-    provider={provider}
-    url="https://example.com"
-    values={[
-      {
-        jsonPath: 'label1',
-        fieldName: 'Label 1',
-        value: 'ABC123',
-      },
-      {
-        jsonPath: 'label2',
-        fieldName: 'Label 2',
-        value: 'ABC123',
-      },
-      {
-        jsonPath: 'label3',
-        fieldName: 'Label 3',
-        value: 'ABC123',
-      },
-      {
-        jsonPath: 'label4',
-        fieldName: 'Label 4',
-        value: 'ABC123',
-      },
-    ]}
-  />
-);
+}: ProviderPanelLoaderProps) => {
+  const allProviderData = useProviderData(externalId);
+  if (allProviderData === null) {
+    return <Loading onClose={onClose} provider={provider} />;
+  }
+  const selectedProviderData = allProviderData.find(
+    ({ platformProvider }) => platformProvider === provider
+  );
+  if (selectedProviderData === undefined) {
+    return <NoData onClose={onClose} provider={provider} />;
+  }
+  const { parse, name } = providers[provider];
+  const { applicant, url, values } = parse(selectedProviderData.data);
+  return (
+    <DataPlatformProviderPanel
+      provider={name}
+      applicant={applicant}
+      url={url}
+      onClose={onClose}
+      values={values}
+    />
+  );
+};
 
 const DataPlatformProviderLoader = ({
   externalId,

--- a/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { ClosablePanel, PanelTitle } from '../Panel';
+import { DataPlatformProviderPanel } from './DataPlatformProviderPanel';
+
+const providers = {
+  candid: {
+    name: 'Candid',
+  },
+  'charity-navigator': {
+    name: 'Charity Navigator',
+  },
+};
+type KnownProvider = keyof typeof providers;
+
+const isValidProvider = (provider: string): provider is KnownProvider => (
+  Object.hasOwn(providers, provider)
+);
+
+interface DataPlatformProviderProps {
+  externalId: string | undefined;
+  onClose: () => void;
+  provider: string;
+}
+
+const Invalid = ({
+  onClose,
+  provider,
+}: Omit<Required<DataPlatformProviderProps>, 'externalId'>) => (
+  <ClosablePanel
+    onClose={onClose}
+    title={(
+      <PanelTitle>
+        Invalid Provider
+      </PanelTitle>
+    )}
+  >
+    {`The data platform provider ${provider} is not recognized.`}
+  </ClosablePanel>
+);
+
+interface ClosableKnownProviderProps {
+  onClose: () => void;
+  provider: KnownProvider;
+}
+const Loading = ({
+  onClose,
+  provider,
+}: ClosableKnownProviderProps) => (
+  <ClosablePanel
+    onClose={onClose}
+    title={(
+      <PanelTitle>
+        {providers[provider].name}
+      </PanelTitle>
+    )}
+  >
+    {`Loading data from ${providers[provider].name}...`}
+  </ClosablePanel>
+);
+
+interface ProviderPanelLoaderProps {
+  externalId: string;
+  onClose: () => void;
+  provider: KnownProvider;
+}
+
+const ProviderPanelLoader = ({
+  externalId,
+  onClose,
+  provider,
+}: ProviderPanelLoaderProps) => (
+  <DataPlatformProviderPanel
+    applicant={externalId}
+    onClose={onClose}
+    provider={provider}
+    url="https://example.com"
+    values={[
+      {
+        jsonPath: 'label1',
+        fieldName: 'Label 1',
+        value: 'ABC123',
+      },
+      {
+        jsonPath: 'label2',
+        fieldName: 'Label 2',
+        value: 'ABC123',
+      },
+      {
+        jsonPath: 'label3',
+        fieldName: 'Label 3',
+        value: 'ABC123',
+      },
+      {
+        jsonPath: 'label4',
+        fieldName: 'Label 4',
+        value: 'ABC123',
+      },
+    ]}
+  />
+);
+
+const DataPlatformProviderLoader = ({
+  externalId,
+  onClose,
+  provider,
+}: DataPlatformProviderProps) => {
+  if (!isValidProvider(provider)) {
+    return <Invalid onClose={onClose} provider={provider} />;
+  }
+  if (externalId === undefined) {
+    return <Loading onClose={onClose} provider={provider} />;
+  }
+  return (
+    <ProviderPanelLoader
+      externalId={externalId}
+      onClose={onClose}
+      provider={provider}
+    />
+  );
+};
+
+export { DataPlatformProviderLoader };

--- a/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
@@ -8,7 +8,7 @@ import { DataPlatformProviderPanel } from './DataPlatformProviderPanel';
 interface JSONPathAll {
   path: string;
   pointer: string;
-  value: string;
+  value: unknown;
 }
 
 const mapPathsToValues = (paths: string[][], data: object) => (
@@ -29,7 +29,9 @@ const mapPathsToValues = (paths: string[][], data: object) => (
       ),
       value,
     }))
-    .filter(({ value }) => typeof value === 'string' && value.trim() != '')
+    .filter(({ value }) => value !== null && value !== undefined)
+    .map(({ value, ...rest }) => ({ value: String(value), ...rest }))
+    .filter(({ value }) => value.trim() !== '')
 );
 
 const providers = {
@@ -80,9 +82,35 @@ const providers = {
   'charity-navigator': {
     name: 'Charity Navigator',
     parse: (data: object) => ({
-      applicant: 'todo',
-      url: 'todo',
-      values: [],
+      applicant: JSONPath<string>({
+        json: data,
+        path: ['$', 'title'],
+        preventEval: true,
+        resultType: 'value',
+        wrap: false,
+      }),
+      url: `https://www.charitynavigator.org${JSONPath<string>({
+        json: data,
+        path: ['$', 'url'],
+        preventEval: true,
+        resultType: 'value',
+        wrap: false,
+      })}`,
+      values: mapPathsToValues([
+        ['$', 'name'],
+        ['$', 'star_rating'],
+        ['$', 'ein'],
+        ['$', 'subsection'],
+        ['$', 'cause'],
+        ['$', 'city'],
+        ['$', 'state'],
+        ['$', 'size'],
+        ['$', 'acronym'],
+        ['$', 'donation_eligible'],
+        ['$', 'encompass_eligible'],
+        ['$', 'highest_level_advisory'],
+        ['$', 'akas', '*'],
+      ], data),
     }),
   },
 };

--- a/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ArrowTopRightOnSquareIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelHeader,
+  PanelTitle,
+  PanelTitleTags,
+  PanelTitleWrapper,
+} from '../Panel';
+import { Button } from '../Button';
+import { OffsiteLink } from '../OffsiteLink';
+import { DataPlatformProviderTable } from './DataPlatformProviderTable';
+
+interface DataPlatformProviderPanelProps {
+  applicant: string;
+  onClose: () => void;
+  provider: string;
+  url: string;
+  values: {
+    jsonPath: string,
+    fieldName: string,
+    value: string,
+  }[];
+}
+
+const DataPlatformProviderPanel = ({
+  applicant,
+  onClose,
+  provider,
+  url,
+  values,
+}: DataPlatformProviderPanelProps) => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        <PanelTitle>
+          {applicant}
+        </PanelTitle>
+        <PanelTitleTags>
+          <OffsiteLink
+            to={url}
+            targetBlank
+            className="panel-tag panel-tag--link"
+          >
+            <ArrowTopRightOnSquareIcon className="icon" />
+            {`Open in ${provider}`}
+          </OffsiteLink>
+        </PanelTitleTags>
+      </PanelTitleWrapper>
+      <PanelActions>
+        <Button
+          onClick={onClose}
+          color="red"
+          title="Close data platform provider panel"
+        >
+          <XMarkIcon className="icon" />
+        </Button>
+      </PanelActions>
+    </PanelHeader>
+    <PanelBody>
+      <DataPlatformProviderTable values={values} />
+    </PanelBody>
+  </Panel>
+);
+
+export { DataPlatformProviderPanel };

--- a/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
@@ -1,17 +1,39 @@
 import React from 'react';
-import { ArrowTopRightOnSquareIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import {
-  Panel,
-  PanelActions,
-  PanelBody,
-  PanelHeader,
+  ClosablePanel,
   PanelTitle,
   PanelTitleTags,
-  PanelTitleWrapper,
 } from '../Panel';
-import { Button } from '../Button';
 import { OffsiteLink } from '../OffsiteLink';
 import { DataPlatformProviderTable } from './DataPlatformProviderTable';
+
+interface DataPlatformProviderTitleProps {
+  applicant: string;
+  provider: string;
+  url: string;
+}
+const DataPlatformProviderTitle = ({
+  applicant,
+  provider,
+  url,
+}: DataPlatformProviderTitleProps) => (
+  <>
+    <PanelTitle>
+      {applicant}
+    </PanelTitle>
+    <PanelTitleTags>
+      <OffsiteLink
+        to={url}
+        targetBlank
+        className="panel-tag panel-tag--link"
+      >
+        <ArrowTopRightOnSquareIcon className="icon" />
+        {`Open in ${provider}`}
+      </OffsiteLink>
+    </PanelTitleTags>
+  </>
+);
 
 interface DataPlatformProviderPanelProps {
   applicant: string;
@@ -32,37 +54,18 @@ const DataPlatformProviderPanel = ({
   url,
   values,
 }: DataPlatformProviderPanelProps) => (
-  <Panel>
-    <PanelHeader>
-      <PanelTitleWrapper>
-        <PanelTitle>
-          {applicant}
-        </PanelTitle>
-        <PanelTitleTags>
-          <OffsiteLink
-            to={url}
-            targetBlank
-            className="panel-tag panel-tag--link"
-          >
-            <ArrowTopRightOnSquareIcon className="icon" />
-            {`Open in ${provider}`}
-          </OffsiteLink>
-        </PanelTitleTags>
-      </PanelTitleWrapper>
-      <PanelActions>
-        <Button
-          onClick={onClose}
-          color="red"
-          title="Close data platform provider panel"
-        >
-          <XMarkIcon className="icon" />
-        </Button>
-      </PanelActions>
-    </PanelHeader>
-    <PanelBody>
-      <DataPlatformProviderTable values={values} />
-    </PanelBody>
-  </Panel>
+  <ClosablePanel
+    onClose={onClose}
+    title={(
+      <DataPlatformProviderTitle
+        applicant={applicant}
+        provider={provider}
+        url={url}
+      />
+    )}
+  >
+    <DataPlatformProviderTable values={values} />
+  </ClosablePanel>
 );
 
 export { DataPlatformProviderPanel };

--- a/src/components/DataPlatformProvider/DataPlatformProviderTable.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderTable.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { CodeBracketSquareIcon as SolidBracketIcon } from '@heroicons/react/24/solid';
+import { CodeBracketSquareIcon as OutlineBracketIcon } from '@heroicons/react/24/outline';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  TableBody,
+  TableRow,
+  RowHead,
+  RowCell,
+  ColumnAction,
+  ColumnActions,
+} from '../Table';
+
+interface DataPlatformProviderTableProps {
+  values: {
+    jsonPath: string,
+    fieldName: string,
+    value: string,
+  }[];
+}
+
+export const DataPlatformProviderTable = ({
+  values,
+}: DataPlatformProviderTableProps) => {
+  const [displayJsonPaths, setDisplayJsonPaths] = useState(false);
+
+  const handleDisplayJsonPathsClick = () => {
+    setDisplayJsonPaths((previous) => !previous);
+  };
+
+  return (
+    <Table>
+      <TableHead fixed>
+        <TableRow>
+          <ColumnHead
+            actions
+            actionAlignment="left"
+          >
+            Field Name
+            <ColumnActions>
+              <ColumnAction
+                title="Toggle between field label and JSON path"
+                onClick={handleDisplayJsonPathsClick}
+              >
+                {displayJsonPaths
+                  ? <SolidBracketIcon className="icon" />
+                  : <OutlineBracketIcon className="icon" />}
+              </ColumnAction>
+            </ColumnActions>
+          </ColumnHead>
+          <ColumnHead>
+            Values
+          </ColumnHead>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {values.map(({
+          jsonPath, fieldName, value,
+        }) => (
+          <TableRow key={jsonPath}>
+            <RowHead>
+              {displayJsonPaths ? <code>{jsonPath}</code> : fieldName}
+            </RowHead>
+            <RowCell>
+              {value}
+            </RowCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/components/Panel/ClosablePanel.tsx
+++ b/src/components/Panel/ClosablePanel.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { XMarkIcon } from '@heroicons/react/24/solid';
+import { Button } from '../Button';
+import { Panel } from './Panel';
+import { PanelHeader } from './PanelHeader';
+import { PanelActions } from './PanelActions';
+import { PanelTitleWrapper } from './PanelTitleWrapper';
+import { PanelBody } from './PanelBody';
+
+interface ClosablePanelProps {
+  children: React.ReactNode;
+  onClose: () => void;
+  title: React.ReactNode;
+}
+
+const ClosablePanel = ({
+  children,
+  onClose,
+  title,
+}: ClosablePanelProps) => (
+  <Panel>
+    <PanelHeader>
+      <PanelTitleWrapper>
+        {title}
+      </PanelTitleWrapper>
+      <PanelActions>
+        <Button
+          onClick={onClose}
+          color="red"
+          title="Close this panel"
+        >
+          <XMarkIcon className="icon" />
+        </Button>
+      </PanelActions>
+    </PanelHeader>
+    <PanelBody>
+      {children}
+    </PanelBody>
+  </Panel>
+);
+
+export { ClosablePanel };

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -49,6 +49,15 @@
   gap: 0.75ch;
 }
 
+.panel-tag--link {
+  color: var(--color--blue);
+}
+
+.panel-tag--link:hover,
+.panel-tag > a:hover {
+  text-decoration: none;
+}
+
 .panel-tag .icon {
   flex-shrink: 0;
   width: var(--icon-size--text);

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -1,3 +1,4 @@
+import { ClosablePanel } from './ClosablePanel';
 import { Panel } from './Panel';
 import { PanelHeader } from './PanelHeader';
 import { PanelActions } from './PanelActions';
@@ -8,6 +9,7 @@ import { PanelTag } from './PanelTag';
 import { PanelBody } from './PanelBody';
 
 export {
+  ClosablePanel,
   Panel,
   PanelHeader,
   PanelActions,

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -25,7 +25,7 @@ interface ProposalDetailPanelProps {
     fieldName: string,
     position: number,
     value: string,
-  }[],
+  }[];
 }
 
 const ProposalDetailPanel = ({

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { BackwardIcon, DocumentTextIcon, ForwardIcon } from '@heroicons/react/24/solid';
+import { ArrowRightOnRectangleIcon, CircleStackIcon } from '@heroicons/react/24/outline';
 import {
   Panel,
   PanelActions,
@@ -13,6 +14,7 @@ import {
 } from './Panel';
 import { ProposalTable } from './ProposalTable';
 import { FormElementGroup } from './FormElementGroup';
+import { Dropdown, DropdownMenuLink, DropdownMenuText } from './Dropdown';
 
 interface ProposalDetailPanelProps {
   title: string | undefined;
@@ -74,6 +76,33 @@ const ProposalDetailPanel = ({
             </Link>
           </FormElementGroup>
         )}
+        <Dropdown
+          align="right"
+          trigger={(
+            <>
+              <CircleStackIcon />
+              Data providers
+            </>
+        )}
+        >
+          <DropdownMenuText>
+            View applicant data from one of the data platform providers:
+          </DropdownMenuText>
+          <DropdownMenuLink
+            to={`/proposals/${proposalId}/provider/candid`}
+            key="candid"
+          >
+            Candid
+            <ArrowRightOnRectangleIcon />
+          </DropdownMenuLink>
+          <DropdownMenuLink
+            to={`/proposals/${proposalId}/provider/charity-navigator`}
+            key="charity-navigator"
+          >
+            Charity Navigator
+            <ArrowRightOnRectangleIcon />
+          </DropdownMenuLink>
+        </Dropdown>
       </PanelActions>
     </PanelHeader>
     <PanelBody>

--- a/src/components/ProposalTable.tsx
+++ b/src/components/ProposalTable.tsx
@@ -20,7 +20,7 @@ interface ProposalTableProps {
     fieldName: string,
     position: number,
     value: string,
-  }[],
+  }[];
 }
 
 export const ProposalTable = ({

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   ApiBaseField,
   ApiProposal,
@@ -12,6 +12,7 @@ import {
   useProposals,
 } from '../pdc-api';
 import { mapProposals } from '../map-proposals';
+import { DataPlatformProviderLoader } from '../components/DataPlatformProvider/DataPlatformProviderLoader';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalDetailPanel } from '../components/ProposalDetailPanel';
 import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
@@ -103,8 +104,10 @@ interface ProposalDetailPanelLoaderProps {
 const ProposalDetailPanelLoader = (
   { baseFields }: ProposalDetailPanelLoaderProps,
 ) => {
+  const navigate = useNavigate();
   const params = useParams();
   const proposalId = params.proposalId ?? 'missing';
+  const { provider } = params;
   const proposal = useProposal(proposalId);
 
   useEffect(() => {
@@ -119,16 +122,27 @@ const ProposalDetailPanelLoader = (
 
   if (baseFields === null || proposal === null) {
     return (
-      <PanelGridItem>
-        <ProposalDetailPanel
-          proposalId={0}
-          title="Loading..."
-          applicant="Loading..."
-          applicantId="00-0000000"
-          version={0}
-          values={[]}
-        />
-      </PanelGridItem>
+      <>
+        <PanelGridItem key="detailPanel">
+          <ProposalDetailPanel
+            proposalId={0}
+            title="Loading..."
+            applicant="Loading..."
+            applicantId="00-0000000"
+            version={0}
+            values={[]}
+          />
+        </PanelGridItem>
+        { provider && (
+          <PanelGridItem key="platformPanel">
+            <DataPlatformProviderLoader
+              externalId={undefined}
+              onClose={() => { navigate(`/proposals/${proposalId}`); }}
+              provider={provider}
+            />
+          </PanelGridItem>
+        )}
+      </>
     );
   }
 
@@ -139,16 +153,27 @@ const ProposalDetailPanelLoader = (
   const values = mapBaseFields(baseFields, proposal);
 
   return (
-    <PanelGridItem>
-      <ProposalDetailPanel
-        proposalId={proposal.id}
-        title={title}
-        applicant={applicant}
-        applicantId={applicantId}
-        version={version}
-        values={values}
-      />
-    </PanelGridItem>
+    <>
+      <PanelGridItem key="detailPanel">
+        <ProposalDetailPanel
+          proposalId={proposal.id}
+          title={title}
+          applicant={applicant}
+          applicantId={applicantId}
+          version={version}
+          values={values}
+        />
+      </PanelGridItem>
+      { provider && (
+        <PanelGridItem key="platformPanel">
+          <DataPlatformProviderLoader
+            provider={provider}
+            externalId={applicantId}
+            onClose={() => { navigate(`/proposals/${proposalId}`); }}
+          />
+        </PanelGridItem>
+      )}
+    </>
   );
 };
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -101,6 +101,22 @@ const useProposals = (page: string, count: string, query: string) => (
   )
 );
 
+interface PlatformProviderResponse {
+  createdAt: string;
+  externalId: string;
+  platformProvider: string;
+  data: object;
+}
+
+const useProviderData = (externalId: string) => (
+  usePdcApi<PlatformProviderResponse[]>(
+    '/platformProviderResponses',
+    new URLSearchParams({
+      externalId,
+    }),
+  )
+);
+
 export {
   PROPOSALS_DEFAULT_COUNT,
   PROPOSALS_DEFAULT_PAGE,
@@ -108,6 +124,7 @@ export {
   useBaseFields,
   useProposal,
   useProposals,
+  useProviderData,
 };
 
 export type {


### PR DESCRIPTION
_This commit ladders off #166._

This PR adds the components and page required to show data platform provider data:

<img width="1793" alt="providers" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/62733e70-9973-4aaf-b19d-d9a0d537e78e">

Some of these commits can be used as-is (pending review), but others are intended only to demonstrate patterns and usage. I expect @jasonaowen will want to take a slightly different tactic for generating the `ProposalDetailWithProvider` page, for instance.

**Testing:**
1. Go to any proposal detail page
2. Use the new "Data providers" dropdown to open a provider panel
3. Data is placeholder, but the close button should work and the link to Candid and Charity Navigator _might_ work. (The URL format is correct, but it's possible the platform doesn't have that EIN.)

**Notes:**
- This is quite messy but a start.
- Doesn't do anything conditional based on whether we have data from one of the platforms; we should add this.
- Hardcodes in the known provider names, and/but doesn't sanitize the URL to only allow known providers.
- In the course of this, "data platform providers" became a dizzyingly difficult name to understand. Are these platforms? Or providers? What is a data platform provider, anyway?
- Doesn't attempt the challenge of mapping keys to labels; assumes it is passed an array of value objects similar to the proposal table.

Issue #23 