### PR TITLE
Improve panel layouts

### DIFF
--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -52,6 +52,7 @@
 }
 
 .panel-tag .icon {
+  flex-shrink: 0;
   width: var(--icon-size--text);
   height: var(--icon-size--text);
 }

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -31,6 +31,7 @@
   display: flex;
   flex-wrap: wrap;
   column-gap: var(--fixed-spacing--2x);
+  row-gap: var(--fixed-spacing--halfx);
 }
 
 .panel-tag {

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -17,10 +17,6 @@
   gap: var(--fixed-spacing--2x);
 }
 
-.panel-title-wrapper {
-  padding-left: var(--fixed-spacing--1x);
-}
-
 .panel-title {
   font-size: 1.5rem;
   font-weight: var(--font-weight--normal);

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -67,6 +67,7 @@
 
 .panel-body {
   grid-row: 2;
+  overflow: auto;
 }
 
 .panel-message {

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -35,6 +35,7 @@
 
 .panel-tag {
   font-weight: var(--font-weight--medium);
+  line-height: 1.1;
   color: var(--color--gray--medium);
 
   display: flex;
@@ -59,6 +60,7 @@
 
 .panel-tag .badge {
   --badge--background-color: var(--color--gray--medium);
+  line-height: var(--line-height);
 }
 
 .panel-actions {

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -12,6 +12,15 @@
 
 .table thead.fixed {
   position: sticky;
+  top: 0;
+}
+
+/* When the panel-body is the first child of the panel --
+   that is to say, when we compose a panel with no panel-header --
+   we want to offset our table's sticky positioning so that
+   the top border of the table scrolls out of panel and avoids a
+   phantom shadow-darkening effect. */
+.panel > .panel-body:first-child > .table thead.fixed {
   top: calc(-1 * var(--table--border-width));
 }
 


### PR DESCRIPTION
This PR includes a few small change to panel elements, all of which improve their layout and behavior in a large number of real-world circumstances:

1. In narrow panels with a long panel tag — especially long enough to wrap — the icon in the panel tag no longer shrinks. (The layout savings are very minimal compared to the UI weirdness of the shrinking.) Also, panel tag text line height is reduced, for a nicer-looking layout when it wraps.
2. Some extraneous padding was removed from around panel titles.
3. Rather than the entire panel scrolling when the panel body was too large, now only the body itself scrolls. The header remains fixed. This resolves the issue in #86 where wide panel body tables were pushing the panel actions out of view, and also allows the header to remain in-view while scrolling the table.

**Testing:**
1. On `main`, load up the Dashboard and wait for the data to load.
2. Note that you can see the Search in the top left, but no panel actions in the top right. Scroll all the way to the right; now, note that you **cannot** see the Search in the top left, but you **can** see the Toggle wrapping button in the top right. This is wrong; you should always be able to see both, positioned in their respective corners.
3. Note also that as you scroll down, the panel header disappears (although the table header remains sticky).
4. Switch to `fix-panel-layout` and re-check the above; all should behave as expected, with the panel header remaining atop the panel as you scroll, and all panel actions being visible/usable at all times.
5. Stretch test: compare the wrapping behavior of panel tags between `main` and this branch to see that it matches the description above, but not really necessary.

Closes #86 