### PR TITLE
Maintain consistent internal button positioning

### DIFF
--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -25,6 +25,7 @@
   font-size: var(--button--font-size);
   line-height: 1;
   letter-spacing: normal;
+  white-space: nowrap;
   height: var(--button--height);
   padding: var(--button--padding-y) var(--button--padding-x);
 
@@ -52,6 +53,7 @@
 }
 
 .button > svg {
+  flex-shrink: 0;
   height: var(--button--icon-size);
   width: var(--button--icon-size);;
 }


### PR DESCRIPTION
This PR improves button display in two ways:

- Don’t allow the icon to shrink; it’s small, there’s no need
- Don’t allow button text to wrap; if we find ourself in this scenario, something else should probably change. (E.g., responsively hiding the text portion of the button, reducing wording, etc.)

**Before,** this was (incorrectly) possible:
<img width="126" alt="Screenshot 2023-05-30 at 5 26 33 PM" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/f3052b8c-1732-415f-ad0b-e05687fb81c1">

**Now,** the interface insists upon maintaining this:
<img width="174" alt="Screenshot 2023-05-30 at 5 26 44 PM" src="https://github.com/PhilanthropyDataCommons/data-viewer/assets/4731/f3c6d370-b2a4-4a7b-b613-539fa66a4995">

Why? Because too often buttons were in contexts (such as a flex layout) that _suggested_ they should reduce in size, when we didn't really want them to. Instead, we tend to want _other_ elements to get out of the way before we modify button layout. If we find some part of the interface where our buttons really are too big, we should address it some other way.