### PR TITLE
Close dropdown when a child link is clicked

### DIFF
--- a/src/components/Dropdown/DropdownMenuLink.tsx
+++ b/src/components/Dropdown/DropdownMenuLink.tsx
@@ -17,8 +17,19 @@ export const DropdownMenuLink = ({
   to,
   children,
   className = '',
-}: DropdownMenuLinkProps) => (
-  <Link to={to} className={`dropdown-menu-link ${className}`.trim()}>
-    {children}
-  </Link>
-);
+}: DropdownMenuLinkProps) => {
+  const handleClick = (e: React.SyntheticEvent) => {
+    const $target = e.nativeEvent.target as HTMLLinkElement;
+    $target.closest('.dropdown')?.removeAttribute('open');
+  };
+
+  return (
+    <Link
+      to={to}
+      className={`dropdown-menu-link ${className}`.trim()}
+      onClick={handleClick}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -62,7 +62,7 @@ export const RightAligned: Story = {
 export const WithIconInTrigger: Story = {
   args: {
     trigger: [
-      <ArrowUpOnSquareIcon />,
+      <ArrowUpOnSquareIcon key="icon" />,
       'Toggle menu',
     ],
     children: [


### PR DESCRIPTION
This PR ensures a dropdown menu closes when a link within is clicked.

@jasonaowen rubber-ducked for a while on where this should live before settling on binding directly to the `Link` within each `DropdownMenuLink` component, and targeting the parent `Dropdown` component using native DOM traversal rather than refs or passing a handler in as a prop. This isn't the most React-idiomatic approach, but it avoids a larger set of complications.

It also fixes a missing key issue in the Dropdown Storybook that I hadn't noticed before.

**Testing:**
1. Go to [`main`'s Dropdown Storybook](https://pilot.philanthropydatacommons.org/storybook/?path=/docs/stories-dropdown--docs)
2. Open a dropdown and click an item inside
3. ❌ Note that the dropdown menu doesn't close!
4. Go to [this branch's Dropdown Storybook](https://deploy-preview-193--philanthropy-data-commons-viewer.netlify.app/storybook/?path=/docs/stories-dropdown--docs)
6. Open a dropdown and click an item inside
7. ✅ Note that the dropdown menu closes!

Closes #190 