### PR TITLE
Add padding to panel bodies by default

### DIFF
--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -30,6 +30,7 @@
   padding: var(--button--padding-y) var(--button--padding-x);
 
   transition-property: background-color, color, border-color, opacity;
+  transition-duration: var(--transition-duration);
 
   display: inline-flex;
   flex-direction: row;

--- a/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderPanel.tsx
@@ -56,6 +56,7 @@ const DataPlatformProviderPanel = ({
 }: DataPlatformProviderPanelProps) => (
   <ClosablePanel
     onClose={onClose}
+    padded={false}
     title={(
       <DataPlatformProviderTitle
         applicant={applicant}

--- a/src/components/Panel/ClosablePanel.tsx
+++ b/src/components/Panel/ClosablePanel.tsx
@@ -11,12 +11,17 @@ interface ClosablePanelProps {
   children: React.ReactNode;
   onClose: () => void;
   title: React.ReactNode;
+  /**
+   * Controls whether the panel body has internal padding.
+   */
+  padded?: boolean;
 }
 
 const ClosablePanel = ({
   children,
   onClose,
   title,
+  padded = true,
 }: ClosablePanelProps) => (
   <Panel>
     <PanelHeader>
@@ -33,7 +38,7 @@ const ClosablePanel = ({
         </Button>
       </PanelActions>
     </PanelHeader>
-    <PanelBody>
+    <PanelBody padded={padded}>
       {children}
     </PanelBody>
   </Panel>

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -86,7 +86,3 @@
 .panel-body--padded {
   padding: var(--panel--padding);
 }
-
-.panel-message {
-  color: var(--color--gray--medium-dark);
-}

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -83,9 +83,3 @@
   padding: var(--fixed-spacing--1x);
   color: var(--color--gray--medium-dark);
 }
-
-.panel.fill .panel-body {
-  position: absolute;
-  inset: 0;
-  overflow: auto;
-}

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -83,7 +83,10 @@
   overflow: auto;
 }
 
+.panel-body--padded {
+  padding: var(--panel--padding);
+}
+
 .panel-message {
   color: var(--color--gray--medium-dark);
-  padding: var(--panel--padding);
 }

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -1,3 +1,7 @@
+:root {
+  --panel--padding: var(--fixed-spacing--1x);
+}
+
 .panel {
   background-color: white;
   border-radius: 5px;
@@ -10,7 +14,7 @@
 
 .panel-header {
   grid-row: 1;
-  padding: var(--fixed-spacing--1x);
+  padding: var(--panel--padding);
 
   display: flex;
   justify-content: space-between;
@@ -80,6 +84,6 @@
 }
 
 .panel-message {
-  padding: var(--fixed-spacing--1x);
   color: var(--color--gray--medium-dark);
+  padding: var(--panel--padding);
 }

--- a/src/components/Panel/PanelBody.tsx
+++ b/src/components/Panel/PanelBody.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 
 interface PanelBodyProps {
   children: React.ReactNode;
+  /**
+   * Controls whether the panel body has internal padding.
+   */
+  padded?: boolean;
   className?: string;
-  fill?: boolean;
 }
 
 export const PanelBody = ({
   children,
   className = '',
-  fill = true,
+  padded = true,
 }: PanelBodyProps) => (
-  <div className={`panel-body ${fill ? 'panel-body--fill' : ''} ${className}`.trim()}>
+  <div className={`panel-body ${padded ? 'panel-body--padded' : ''} ${className}`.trim()}>
     {children}
   </div>
 );

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -105,7 +105,7 @@ const ProposalDetailPanel = ({
         </Dropdown>
       </PanelActions>
     </PanelHeader>
-    <PanelBody>
+    <PanelBody padded={false}>
       <ProposalTable
         version={version}
         values={values}

--- a/src/components/ProposalListGridPanel.tsx
+++ b/src/components/ProposalListGridPanel.tsx
@@ -12,7 +12,7 @@ interface ProposalListGridPanelProps {
 
 export const ProposalListGridPanel = ({ proposals }: ProposalListGridPanelProps) => (
   <Panel>
-    <PanelBody>
+    <PanelBody padded={false}>
       <ProposalListGrid proposals={proposals} />
     </PanelBody>
   </Panel>

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -81,7 +81,7 @@ export const ProposalListTablePanel = ({
           </PanelActions>
         )}
       </PanelHeader>
-      <PanelBody>
+      <PanelBody padded={!hasProposals}>
         {hasProposals ? (
           <ProposalListTable
             fieldNames={fieldNames}

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -90,7 +90,7 @@ export const ProposalListTablePanel = ({
             wrap={wrap}
           />
         ) : (
-          <div className="panel-message">
+          <div className="quiet">
             {generateFallbackMessage()}
           </div>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -60,7 +60,6 @@ code {
 *:before,
 *:after {
   box-sizing: border-box;
-  transition-duration: var(--transition-duration);
 }
 
 nav ul,

--- a/src/index.css
+++ b/src/index.css
@@ -128,8 +128,7 @@ code {
   font-size: 0.8em;
 }
 
-.subtle {
-  font-size: 0.85em;
+.quiet {
   color: var(--color--gray--medium-dark);
 }
 

--- a/src/pages/Landing.css
+++ b/src/pages/Landing.css
@@ -1,8 +1,6 @@
 .landing-panel {
   max-width: 60ch;
   margin: var(--fixed-spacing--2x) auto;
-}
 
-.landing-panel .panel-body {
-  padding: var(--fixed-spacing--2x);
+  --panel--padding: var(--fixed-spacing--2x);
 }


### PR DESCRIPTION
This PR reformats our `PanelBody` components so that, by default, they have an internal padding that matches the `PanelHeader` padding. This makes them more usable as-is without any further styling. The padding can be removed with the new `padded` prop, which removes the padding for a more "full-panel" interface that we often use.

This required adding the `padded` prop to multiple components and changing the `ClosablePanel` component to pass it through as well.

**Testing:**
- Most panels should look the same as they did before
- The "Loading…" and "No data found" versions of the data platform provider panels should now appear with padding, so the messages are no longer flush with the edge

**Regression note:**

There is one big regression that I don't like and can't figure out: when the Dashboard panel re-renders from "Loading" to have content, we also flip from padded to not padded. I would expect this change to be instantaneous; that is, as soon as the table appears, it is already in an unpadded `PanelBody`. But it seems to render into the padded `PanelBody` and _then_ very quickly the padding is removed, causing an unsightly reformatting flash as the table repositions. I don't like this but couldn't solve it, and welcome suggestions.

Closes #195 