### PR TITLE
Remove next/prev proposal buttons

### DIFF
--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { BackwardIcon, DocumentTextIcon, ForwardIcon } from '@heroicons/react/24/solid';
+import { DocumentTextIcon } from '@heroicons/react/24/solid';
 import { ArrowRightOnRectangleIcon, CircleStackIcon } from '@heroicons/react/24/outline';
 import {
   Panel,
@@ -13,7 +12,6 @@ import {
   PanelTitleWrapper,
 } from './Panel';
 import { ProposalTable } from './ProposalTable';
-import { FormElementGroup } from './FormElementGroup';
 import { Dropdown, DropdownMenuLink, DropdownMenuText } from './Dropdown';
 
 interface ProposalDetailPanelProps {
@@ -58,24 +56,6 @@ const ProposalDetailPanel = ({
         </PanelTitleTags>
       </PanelTitleWrapper>
       <PanelActions>
-        {process.env.NODE_ENV !== 'production' && (
-          <FormElementGroup>
-            <Link
-              to={`/proposals/${proposalId - 1}`}
-              className="button button--color-gray"
-              title="Previous proposal"
-            >
-              <BackwardIcon className="icon" />
-            </Link>
-            <Link
-              to={`/proposals/${proposalId + 1}`}
-              className="button button--color-gray"
-              title="Next proposal"
-            >
-              <ForwardIcon className="icon" />
-            </Link>
-          </FormElementGroup>
-        )}
         <Dropdown
           align="right"
           trigger={(


### PR DESCRIPTION
_This PR ladders off #200; otherwise, removing this block of code would cause the linter to want me to remove the `proposalId` reference, but #200 uses that reference. It would cause unnecessary churn to have started this off `main`._

This PR removes the dev-only next/previous arrows in the top-right of the proposal detail panel. Now that we have a sidebar, we no longer need this convenience.

**Testing:**

Because this is a dev feature, testing must be done when running the app in dev mode (like, locally). The deploy preview isn't sufficient.

1. On `main`, go to a proposal detail page.
2. Note the left/right arrows in the top right of the detail panel.
3. Switch to this branch and check again.
4. ✅ Note the absence of the left/right arrows.

Closes #172