### PR TITLE
Allow text selection on proposal list table

### DIFF
--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -23,7 +23,10 @@ const ProposalListTableRow = ({
   const navigate = useNavigate();
 
   const handleRowClick = () => {
-    navigate(`/proposals/${proposal.id}`);
+    // Only navigate if we didn't just finish selecting text.
+    if (window.getSelection()?.isCollapsed) {
+      navigate(`/proposals/${proposal.id}`);
+    }
   };
 
   const getProposalCellContents = (shortCode: string) => (shortCode === 'organization_name'


### PR DESCRIPTION
This PR enables text selection on the proposal list table by modifying the click handler to only navigate to the proposal detail page if it can tell the "click" is not just the end of a text selection.

Note: This intentionally only applies to the proposal list **table**, not the grid/sidebar. That's because the need to select text in the sidebar is low, while supporting text selection within a `Link` component (aka `a` element) would conflict with default browser behavior like the ability to drag a link to the toolbar to bookmark or open a new tab.

**Testing:**
1. On `main`, go to the Dashboard
2. Attempt to select text in any of the proposal rows
3. ❌ Be stymied because the page navigates to the proposal detail page.
4. On this branch, go to the Dashboard.
5. Attempt to select text in any of the proposal rows.
6. ✅ Be successful, rejoice, shower blessings upon me.

Closes #85