### PR TITLE
Add RECENT_CHANGES document and link to it

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,0 +1,26 @@
+# Recent Changes to the PDC Data Viewer
+
+## June 2023
+
+- Add the ability to show applicant data from data platform providers,
+  starting with Candid and Charity Navigator
+- Highlight current proposal in sidebar
+- Allow text selection on Dashboard table
+
+## May 2023
+
+- Add search capability to Dashboard
+- Add sidebar to proposal detail page
+- Improve performance using batched API queries
+- Improve selection of applicant name across varying base fields
+- Improve rendering of Dashboard table across viewport sizes
+
+## April 2023
+
+🚀 Pilot launched! The initial version featured:
+
+- Data from 100+ proposals imported into the PDC
+- Keycloak-based user system with two-factor authentication via SMS
+- Dashboard of all proposals
+- Ability to drill into each proposal to view all its fields
+- Ability to toggle between field names and keys/shortcodes

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -69,6 +69,16 @@ const Landing = () => {
               />
             </dd>
           </Dli>
+          <Dli>
+            <dt>Recent improvements</dt>
+            <dd>
+              <OffsiteLink
+                to="https://github.com/PhilanthropyDataCommons/data-viewer/blob/main/RECENT_CHANGES.md"
+              >
+                Read a summary of recent changes here.
+              </OffsiteLink>
+            </dd>
+          </Dli>
         </dl>
       </PanelBody>
     </Panel>


### PR DESCRIPTION
This PR adds the `RECENT_CHANGES.md` document we discussed in #39, populates it with some suggested content, and modifies the landing page to link to it. (Note that this link won't actually working until this PR is merged in, but I don't think that weirdness should stop us from treating this as a single PR.)

Please feel free to suggest edits/additions to the recent changes! I'm tagging everyone on this review because suggestions for populating the change list are welcome from anyone. Please do read [this comment](https://github.com/PhilanthropyDataCommons/data-viewer/issues/39#issuecomment-1603439095) first, which explains what sort of changes we want to record here. (It's not a technical CHANGELOG.) 

Closes #39