### PR TITLE
Improve interactive button styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,15 +52,11 @@ button.App-navbar__item {
   cursor: pointer;
 }
 
-.App-navbar__item:focus {
-  outline: 2px solid blue;
-}
-
 .App-navbar__item.active {
   color: var(--color--blue);
 }
 
-.App-navbar__item:is(a, button):hover {
+.App-navbar__item:is(a, button):is(:hover, :focus) {
   background-color: #0001;
 }
 

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -1,5 +1,4 @@
 :root {
-  --button--focus-color: blue;
   --button--font-size: 1rem;
   --button--border-radius: 8px;
   /* These next values should be relative to the button's font-size, so we switch to `em` units. */
@@ -29,8 +28,8 @@
   height: var(--button--height);
   padding: var(--button--padding-y) var(--button--padding-x);
 
-  transition-property: background-color, color, border-color, opacity;
-  transition-duration: var(--transition-duration);
+  transition-property: background-color, color, border-color, outline, opacity;
+  transition-duration: var(--transition-duration--cursor);
 
   display: inline-flex;
   flex-direction: row;
@@ -44,8 +43,12 @@
   color: var(--button--primary-color);
 }
 
-.button:focus {
-  outline: 2px solid var(--button--focus-color);
+.button:not(:disabled):is(:hover, :focus, :active) {
+  background-color: var(--button--contrast-color--accent);
+}
+
+.button:not(:disabled):active {
+  outline: 2px solid var(--button--primary-color--accent);
 }
 
 .button:disabled {
@@ -61,17 +64,23 @@
 
 .button--color-gray {
   --button--primary-color: var(--color--gray--dark);
+  --button--primary-color--accent: var(--color--gray--darker);
   --button--contrast-color: var(--color--gray--lighter);
+  --button--contrast-color--accent: var(--color--gray--light);
 }
 
 .button--color-blue {
   --button--primary-color: var(--color--blue);
+  --button--primary-color--accent: var(--color--blue--dark);
   --button--contrast-color: var(--color--gray--lighter);
+  --button--contrast-color--accent: var(--color--gray--light);
 }
 
 .button--color-red {
   --button--primary-color: var(--color--red);
+  --button--primary-color--accent: var(--color--red--dark);
   --button--contrast-color: var(--color--gray--lighter);
+  --button--contrast-color--accent: var(--color--gray--light);
 }
 
 .button--inverted {
@@ -79,6 +88,14 @@
   --button--notification-color: var(--button--contrast-color);
   background-color: var(--button--primary-color);
   color: var(--button--contrast-color);
+}
+
+.button--inverted:not(:disabled):is(:hover, :focus, :active) {
+  background-color: var(--button--primary-color--accent);
+}
+
+.button--inverted:not(:disabled):active {
+  outline: 2px solid var(--button--primary-color--accent);
 }
 
 .button--bordered {

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -56,7 +56,7 @@
 .button > svg {
   flex-shrink: 0;
   height: var(--button--icon-size);
-  width: var(--button--icon-size);;
+  width: var(--button--icon-size);
 }
 
 .button--color-gray {

--- a/src/components/FormElementGroup.css
+++ b/src/components/FormElementGroup.css
@@ -3,7 +3,7 @@
   gap: 0;
 }
 
-.form-element-group > *:focus {
+.form-element-group > *:is(:focus, :active) {
   z-index: 1;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,9 @@
   --accessible-spacing--halfx: calc(var(--accessible-spacing--1x) / 2);
 
   --transition-duration: 200ms;
+  /* `cursor` should be faster than the standard duration,
+     for things like hover events. */
+  --transition-duration--cursor: 100ms;
 
   --icon-size--text: 1.25em;
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,10 @@
   --color--gray--medium: #BBB;
   --color--gray--light: #EFEFEF;
   --color--gray--lighter: #FAFAFA;
+  --color--blue--dark: #0B5C96;
   --color--blue: #1176BC;
   --color--blue--lighter: #e7f5fe;
+  --color--red--dark: #701F1F;
   --color--red: #892929;
 
   --font-size: 16px;

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -58,7 +58,22 @@ export const WithIconAndNotification: Story = {
 
 export const Inverted: Story = {
   args: {
+    inverted: true,
+    children: 'Button',
+  },
+};
+
+export const InvertedBlue: Story = {
+  args: {
     color: 'blue',
+    inverted: true,
+    children: 'Button',
+  },
+};
+
+export const InvertedRed: Story = {
+  args: {
+    color: 'red',
     inverted: true,
     children: 'Button',
   },


### PR DESCRIPTION
Prior to this PR, the only interaction that button/form elements had was to gain a garish blue outline when focused. This PR:

- Adds hover state (slight darkening of background)
- Uses the hover state as the focus state
- Adds the outline to the active state (when the button is being pressed)
  - It pointedly does _not_ use the outline for the focus state anymore, since that remains after click (until the element is "blurred" but clicking/interacting elsewhere), and the outline is too large of a UI element to leave vestigially.

It also removes the focus ring from the app navbar, which now just has a simple background color change for both hover and focus.

**Testing:**
- `npm run storybook` and tinker with the [Story](http://localhost:6006/?path=/docs/stories-button--docs)
- `npm start` and make sure everything looks nice

Closes #173