### PR TITLE
Set Dependabot to open PRs at noon Pacific

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      timezone: "America/Los_Angeles"
+      time: "12:00"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@types/node"
@@ -18,3 +20,5 @@ updates:
     directory: ".github/workflows"
     schedule:
       interval: "daily"
+      timezone: "America/Los_Angeles"
+      time: "12:00"


### PR DESCRIPTION
Configure Dependabot to create pull requests during business hours.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime