### PR TITLE
Group Dependabot updates to Storybook and React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,18 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
-      - dependency-name: "*storybook*"
-        # Dependabot is not yet able to upgrade all the dependencies together,
-        # which leads to mixed versions and quite a lot of PR thrash.
-        # See https://github.com/dependabot/dependabot-core/issues/1190
+    groups:
+      storybook:
+        dependency-type: "development"
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"


### PR DESCRIPTION
We have two sets of dependencies that should only ever be updated together, and never separately. React updates rarely, but we'd previously disabled Dependabot updates to Storybook because there were so many components and Dependabot would open a PR for each.

However, GitHub [recently](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/) released support for [grouped updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)! With this feature, we can define groups that Dependabot should open one collective PR for, rather than separate PRs.

Define groups for React and Storybook, and allow Dependabot to update Storybook again.